### PR TITLE
Pin GitHub Actions to SHA and add dependabot

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
Pin all GitHub Actions to specific SHAs for better security and reproducibility.

## Changes
- ci.yml: Pin actions/checkout and actions/setup-node to SHAs
- release-drafter.yml: Pin all actions to SHAs  
- .github/dependabot.yml: Add configuration for weekly auto-updates on Friday 21:00 JST

## Verification
- ✓ npm run test
- ✓ npm run typecheck
- ✓ npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub Actionsワークフローを更新し、トリガー条件を調整し、アクション依存関係をピン留めしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->