### PR TITLE
Persist book table filters and sorting to URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,14 @@
 - Think and work in **English**
 - Use the same language as the user for confirmations and final reports
 
+## Testing Mantine Components
+
+When writing tests for Mantine components, refer to these docs as needed:
+
+- Jest/Vitest setup: https://github.com/mantinedev/mantine/blob/master/apps/mantine.dev/src/pages/guides/jest.mdx
+- Testing Select/MultiSelect (combobox): https://github.com/mantinedev/mantine/blob/master/apps/help.mantine.dev/src/pages/q/combobox-testing.mdx
+- Testing Modal/Drawer/Popover (portals): https://github.com/mantinedev/mantine/blob/master/apps/help.mantine.dev/src/pages/q/portals-testing.mdx
+
 ## Pre-commit Checklist
 
 Before committing changes, always run the following commands to ensure code quality:

--- a/e2e/books.spec.ts
+++ b/e2e/books.spec.ts
@@ -309,6 +309,7 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
     await expect(
       page.getByRole("link", { name: "テスト書籍1" }),
     ).not.toBeVisible();
+    await expect(page).toHaveURL(/columnFilters/);
 
     await page.reload();
     await expect(page.getByRole("link", { name: "テスト書籍2" })).toBeVisible();
@@ -323,7 +324,7 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
 
   test("sort persists on page reload", async ({ page }) => {
     await page.getByRole("columnheader", { name: "優先度" }).click();
-    await expect(page.getByRole("link", { name: "テスト書籍2" })).toBeVisible();
+    await expect(page).toHaveURL(/sorting/);
 
     await page.reload();
     await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();

--- a/e2e/books.spec.ts
+++ b/e2e/books.spec.ts
@@ -209,14 +209,11 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/books");
     await page.getByRole("button", { name: "Login" }).click();
-    // Wait for all 4 seed books to be visible
     await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
     await expect(page.getByRole("link", { name: "テスト書籍2" })).toBeVisible();
     await expect(page.getByRole("link", { name: "テスト書籍3" })).toBeVisible();
     await expect(page.getByRole("link", { name: "テスト書籍4" })).toBeVisible();
   });
-
-  // --- Filter tests ---
 
   test("read filter: true shows only read books", async ({ page }) => {
     const readFilter = page.getByTestId("filter-read");
@@ -288,7 +285,6 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
   test("reset filter: clears all filters and shows all books", async ({
     page,
   }) => {
-    // Apply a filter first
     const readFilter = page.getByTestId("filter-read");
     await readFilter.getByRole("textbox").click();
     await page.getByRole("option", { name: "true" }).click();
@@ -296,7 +292,6 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
       page.getByRole("link", { name: "テスト書籍1" }),
     ).not.toBeVisible();
 
-    // Reset
     await page
       .getByRole("button", { name: "Reset filter", exact: true })
       .click();
@@ -307,10 +302,7 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
     await expect(page.getByRole("link", { name: "テスト書籍4" })).toBeVisible();
   });
 
-  // --- URL persistence tests (verify state survives page reload) ---
-
   test("filter persists on page reload", async ({ page }) => {
-    // Apply read=true filter
     const readFilter = page.getByTestId("filter-read");
     await readFilter.getByRole("textbox").click();
     await page.getByRole("option", { name: "true" }).click();
@@ -318,7 +310,6 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
       page.getByRole("link", { name: "テスト書籍1" }),
     ).not.toBeVisible();
 
-    // Reload page — filter must survive via URL params
     await page.reload();
     await expect(page.getByRole("link", { name: "テスト書籍2" })).toBeVisible();
     await expect(page.getByRole("link", { name: "テスト書籍4" })).toBeVisible();
@@ -331,17 +322,12 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
   });
 
   test("sort persists on page reload", async ({ page }) => {
-    // Click priority header once — for numeric columns TanStack Table first click = descending
     await page.getByRole("columnheader", { name: "優先度" }).click();
-
-    // Verify sort applied: book2 (priority=80) should appear before book4 (priority=10)
     await expect(page.getByRole("link", { name: "テスト書籍2" })).toBeVisible();
 
-    // Reload page — sort must survive via URL params
     await page.reload();
     await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
 
-    // Verify sort still applied after reload: priority desc means book2(80) before book4(10)
     const rowsAfterReload = await page
       .getByRole("row")
       .filter({ hasText: /テスト書籍[1-4]/ })
@@ -352,12 +338,10 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
     );
     const book2Index = texts.findIndex((t) => t?.includes("テスト書籍2"));
     const book4Index = texts.findIndex((t) => t?.includes("テスト書籍4"));
-    // book2 (priority=80) should come before book4 (priority=10) in descending sort
     expect(book2Index).toBeLessThan(book4Index);
   });
 
   test("reset clears filter URL params", async ({ page }) => {
-    // Apply a filter so columnFilters appears in URL
     const readFilter = page.getByTestId("filter-read");
     await readFilter.getByRole("textbox").click();
     await page.getByRole("option", { name: "true" }).click();
@@ -365,17 +349,14 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
       page.getByRole("link", { name: "テスト書籍1" }),
     ).not.toBeVisible();
 
-    // Apply a sort so sorting appears in URL
     await page.getByRole("columnheader", { name: "優先度" }).click();
     await expect(page).toHaveURL(/sorting/);
 
-    // Reset
     await page
       .getByRole("button", { name: "Reset filter", exact: true })
       .click();
     await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
 
-    // URL should have neither columnFilters nor sorting param
     const url = new URL(page.url());
     expect(url.searchParams.has("columnFilters")).toBe(false);
     expect(url.searchParams.has("sorting")).toBe(false);

--- a/e2e/books.spec.ts
+++ b/e2e/books.spec.ts
@@ -220,7 +220,7 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
 
   test("read filter: true shows only read books", async ({ page }) => {
     const readFilter = page.getByTestId("filter-read");
-    await readFilter.getByRole("combobox").click();
+    await readFilter.getByRole("textbox").click();
     await page.getByRole("option", { name: "true" }).click();
 
     await expect(page.getByRole("link", { name: "テスト書籍2" })).toBeVisible();
@@ -235,7 +235,7 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
 
   test("owned filter: true shows only owned books", async ({ page }) => {
     const ownedFilter = page.getByTestId("filter-owned");
-    await ownedFilter.getByRole("combobox").click();
+    await ownedFilter.getByRole("textbox").click();
     await page.getByRole("option", { name: "true" }).click();
 
     await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
@@ -250,7 +250,7 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
 
   test("format filter: Printed shows only printed books", async ({ page }) => {
     const formatFilter = page.getByTestId("filter-format");
-    await formatFilter.getByRole("combobox").click();
+    await formatFilter.getByRole("textbox").click();
     await page.getByRole("option", { name: "Printed" }).click();
 
     await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
@@ -290,14 +290,14 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
   }) => {
     // Apply a filter first
     const readFilter = page.getByTestId("filter-read");
-    await readFilter.getByRole("combobox").click();
+    await readFilter.getByRole("textbox").click();
     await page.getByRole("option", { name: "true" }).click();
     await expect(
       page.getByRole("link", { name: "テスト書籍1" }),
     ).not.toBeVisible();
 
     // Reset
-    await page.getByRole("button", { name: "Reset filter" }).click();
+    await page.getByRole("button", { name: "Reset filter", exact: true }).click();
 
     await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
     await expect(page.getByRole("link", { name: "テスト書籍2" })).toBeVisible();
@@ -310,7 +310,7 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
   test("filter persists on page reload", async ({ page }) => {
     // Apply read=true filter
     const readFilter = page.getByTestId("filter-read");
-    await readFilter.getByRole("combobox").click();
+    await readFilter.getByRole("textbox").click();
     await page.getByRole("option", { name: "true" }).click();
     await expect(
       page.getByRole("link", { name: "テスト書籍1" }),
@@ -329,17 +329,17 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
   });
 
   test("sort persists on page reload", async ({ page }) => {
-    // Click priority header once — TanStack Table first click = ascending (lowest first)
+    // Click priority header once — for numeric columns TanStack Table first click = descending
     await page.getByRole("columnheader", { name: "優先度" }).click();
 
-    // Verify sort applied: book4 (priority=10) should be visible (it's the lowest)
-    await expect(page.getByRole("link", { name: "テスト書籍4" })).toBeVisible();
+    // Verify sort applied: book2 (priority=80) should appear before book4 (priority=10)
+    await expect(page.getByRole("link", { name: "テスト書籍2" })).toBeVisible();
 
     // Reload page — sort must survive via URL params
     await page.reload();
     await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
 
-    // Verify sort still applied after reload: priority asc means book4(10) before book1(50)
+    // Verify sort still applied after reload: priority desc means book2(80) before book4(10)
     const rowsAfterReload = await page
       .getByRole("row")
       .filter({ hasText: /テスト書籍[1-4]/ })
@@ -348,23 +348,23 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
     const texts = await Promise.all(
       rowsAfterReload.map((r) => r.textContent()),
     );
+    const book2Index = texts.findIndex((t) => t?.includes("テスト書籍2"));
     const book4Index = texts.findIndex((t) => t?.includes("テスト書籍4"));
-    const book1Index = texts.findIndex((t) => t?.includes("テスト書籍1"));
-    // book4 (priority=10) should come before book1 (priority=50) in ascending sort
-    expect(book4Index).toBeLessThan(book1Index);
+    // book2 (priority=80) should come before book4 (priority=10) in descending sort
+    expect(book2Index).toBeLessThan(book4Index);
   });
 
   test("reset clears filter URL params", async ({ page }) => {
     // Apply a filter so URL gets params
     const readFilter = page.getByTestId("filter-read");
-    await readFilter.getByRole("combobox").click();
+    await readFilter.getByRole("textbox").click();
     await page.getByRole("option", { name: "true" }).click();
     await expect(
       page.getByRole("link", { name: "テスト書籍1" }),
     ).not.toBeVisible();
 
     // Reset
-    await page.getByRole("button", { name: "Reset filter" }).click();
+    await page.getByRole("button", { name: "Reset filter", exact: true }).click();
     await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
 
     // URL should have no columnFilters param

--- a/e2e/books.spec.ts
+++ b/e2e/books.spec.ts
@@ -357,7 +357,7 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
   });
 
   test("reset clears filter URL params", async ({ page }) => {
-    // Apply a filter so URL gets params
+    // Apply a filter so columnFilters appears in URL
     const readFilter = page.getByTestId("filter-read");
     await readFilter.getByRole("textbox").click();
     await page.getByRole("option", { name: "true" }).click();
@@ -365,13 +365,17 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
       page.getByRole("link", { name: "テスト書籍1" }),
     ).not.toBeVisible();
 
+    // Apply a sort so sorting appears in URL
+    await page.getByRole("columnheader", { name: "優先度" }).click();
+    await expect(page).toHaveURL(/sorting/);
+
     // Reset
     await page
       .getByRole("button", { name: "Reset filter", exact: true })
       .click();
     await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
 
-    // URL should have no columnFilters param
+    // URL should have neither columnFilters nor sorting param
     const url = new URL(page.url());
     expect(url.searchParams.has("columnFilters")).toBe(false);
     expect(url.searchParams.has("sorting")).toBe(false);

--- a/e2e/books.spec.ts
+++ b/e2e/books.spec.ts
@@ -329,25 +329,17 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
   });
 
   test("sort persists on page reload", async ({ page }) => {
-    // Click priority header to sort descending
-    await page
-      .getByRole("columnheader", { name: "優先度" })
-      .locator("span")
-      .first()
-      .click();
+    // Click priority header once — TanStack Table first click = ascending (lowest first)
+    await page.getByRole("columnheader", { name: "優先度" }).click();
 
-    // Verify sort applied: book2 (priority=80) should appear before book4 (priority=10)
-    const rows = page.getByRole("row");
-    const book2Row = rows.filter({ hasText: "テスト書籍2" });
-    const book4Row = rows.filter({ hasText: "テスト書籍4" });
-    await expect(book2Row).toBeVisible();
-    await expect(book4Row).toBeVisible();
+    // Verify sort applied: book4 (priority=10) should be visible (it's the lowest)
+    await expect(page.getByRole("link", { name: "テスト書籍4" })).toBeVisible();
 
     // Reload page — sort must survive via URL params
     await page.reload();
     await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
 
-    // Verify sort still applied after reload: priority desc means book2(80) before book4(10)
+    // Verify sort still applied after reload: priority asc means book4(10) before book1(50)
     const rowsAfterReload = await page
       .getByRole("row")
       .filter({ hasText: /テスト書籍[1-4]/ })
@@ -356,10 +348,10 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
     const texts = await Promise.all(
       rowsAfterReload.map((r) => r.textContent()),
     );
-    const book2Index = texts.findIndex((t) => t?.includes("テスト書籍2"));
+    const book4Index = texts.findIndex((t) => t?.includes("テスト書籍4"));
     const book1Index = texts.findIndex((t) => t?.includes("テスト書籍1"));
-    // book2 (priority=80) should come before book1 (priority=50)
-    expect(book2Index).toBeLessThan(book1Index);
+    // book4 (priority=10) should come before book1 (priority=50) in ascending sort
+    expect(book4Index).toBeLessThan(book1Index);
   });
 
   test("reset clears filter URL params", async ({ page }) => {

--- a/e2e/books.spec.ts
+++ b/e2e/books.spec.ts
@@ -1,5 +1,14 @@
-import { expect } from "@playwright/test";
+import { type Page, expect } from "@playwright/test";
 import { test } from "./fixtures";
+
+const selectFilterOption = async (
+  page: Page,
+  testId: string,
+  optionName: string,
+) => {
+  await page.getByTestId(testId).getByRole("textbox").click();
+  await page.getByRole("option", { name: optionName }).click();
+};
 
 test.describe("Books READ", () => {
   test.beforeEach(async ({ page }) => {
@@ -216,9 +225,7 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
   });
 
   test("read filter: true shows only read books", async ({ page }) => {
-    const readFilter = page.getByTestId("filter-read");
-    await readFilter.getByRole("textbox").click();
-    await page.getByRole("option", { name: "true" }).click();
+    await selectFilterOption(page, "filter-read", "true");
 
     await expect(page.getByRole("link", { name: "テスト書籍2" })).toBeVisible();
     await expect(page.getByRole("link", { name: "テスト書籍4" })).toBeVisible();
@@ -231,9 +238,7 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
   });
 
   test("owned filter: true shows only owned books", async ({ page }) => {
-    const ownedFilter = page.getByTestId("filter-owned");
-    await ownedFilter.getByRole("textbox").click();
-    await page.getByRole("option", { name: "true" }).click();
+    await selectFilterOption(page, "filter-owned", "true");
 
     await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
     await expect(page.getByRole("link", { name: "テスト書籍2" })).toBeVisible();
@@ -246,9 +251,7 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
   });
 
   test("format filter: Printed shows only printed books", async ({ page }) => {
-    const formatFilter = page.getByTestId("filter-format");
-    await formatFilter.getByRole("textbox").click();
-    await page.getByRole("option", { name: "Printed" }).click();
+    await selectFilterOption(page, "filter-format", "Printed");
 
     await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
     await expect(
@@ -285,9 +288,7 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
   test("reset filter: clears all filters and shows all books", async ({
     page,
   }) => {
-    const readFilter = page.getByTestId("filter-read");
-    await readFilter.getByRole("textbox").click();
-    await page.getByRole("option", { name: "true" }).click();
+    await selectFilterOption(page, "filter-read", "true");
     await expect(
       page.getByRole("link", { name: "テスト書籍1" }),
     ).not.toBeVisible();
@@ -303,9 +304,7 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
   });
 
   test("filter persists on page reload", async ({ page }) => {
-    const readFilter = page.getByTestId("filter-read");
-    await readFilter.getByRole("textbox").click();
-    await page.getByRole("option", { name: "true" }).click();
+    await selectFilterOption(page, "filter-read", "true");
     await expect(
       page.getByRole("link", { name: "テスト書籍1" }),
     ).not.toBeVisible();
@@ -349,9 +348,7 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
   });
 
   test("reset clears filter URL params", async ({ page }) => {
-    const readFilter = page.getByTestId("filter-read");
-    await readFilter.getByRole("textbox").click();
-    await page.getByRole("option", { name: "true" }).click();
+    await selectFilterOption(page, "filter-read", "true");
     await expect(
       page.getByRole("link", { name: "テスト書籍1" }),
     ).not.toBeVisible();
@@ -363,10 +360,8 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
       .getByRole("button", { name: "Reset filter", exact: true })
       .click();
     await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
-
-    const url = new URL(page.url());
-    expect(url.searchParams.has("columnFilters")).toBe(false);
-    expect(url.searchParams.has("sorting")).toBe(false);
+    await expect(page).not.toHaveURL(/columnFilters/);
+    await expect(page).not.toHaveURL(/sorting/);
   });
 });
 

--- a/e2e/books.spec.ts
+++ b/e2e/books.spec.ts
@@ -297,7 +297,9 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
     ).not.toBeVisible();
 
     // Reset
-    await page.getByRole("button", { name: "Reset filter", exact: true }).click();
+    await page
+      .getByRole("button", { name: "Reset filter", exact: true })
+      .click();
 
     await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
     await expect(page.getByRole("link", { name: "テスト書籍2" })).toBeVisible();
@@ -364,7 +366,9 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
     ).not.toBeVisible();
 
     // Reset
-    await page.getByRole("button", { name: "Reset filter", exact: true }).click();
+    await page
+      .getByRole("button", { name: "Reset filter", exact: true })
+      .click();
     await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
 
     // URL should have no columnFilters param

--- a/e2e/books.spec.ts
+++ b/e2e/books.spec.ts
@@ -326,6 +326,14 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
     await page.getByRole("columnheader", { name: "優先度" }).click();
     await expect(page).toHaveURL(/sorting/);
 
+    const rowsBeforeReload = await page
+      .getByRole("row")
+      .filter({ hasText: /テスト書籍[1-4]/ })
+      .all();
+    const textsBeforeReload = await Promise.all(
+      rowsBeforeReload.map((r) => r.textContent()),
+    );
+
     await page.reload();
     await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
 
@@ -333,13 +341,11 @@ test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
       .getByRole("row")
       .filter({ hasText: /テスト書籍[1-4]/ })
       .all();
-    expect(rowsAfterReload.length).toBe(4);
-    const texts = await Promise.all(
+    const textsAfterReload = await Promise.all(
       rowsAfterReload.map((r) => r.textContent()),
     );
-    const book2Index = texts.findIndex((t) => t?.includes("テスト書籍2"));
-    const book4Index = texts.findIndex((t) => t?.includes("テスト書籍4"));
-    expect(book2Index).toBeLessThan(book4Index);
+
+    expect(textsAfterReload).toEqual(textsBeforeReload);
   });
 
   test("reset clears filter URL params", async ({ page }) => {

--- a/e2e/books.spec.ts
+++ b/e2e/books.spec.ts
@@ -108,7 +108,7 @@ test.describe("Books CREATE", () => {
 
     // Verify created book details
     await page.getByRole("link", { name: "新しい書籍" }).click();
-    await expect(page).toHaveURL(/\/books\/book-3$/);
+    await expect(page).toHaveURL(/\/books\/book-5$/);
     await expect(page.getByText("9784000000010")).toBeVisible();
     await expect(page.locator("text=著者1").first()).toBeVisible();
   });
@@ -202,6 +202,183 @@ test.describe("Books UPDATE", () => {
 
     await page.getByRole("link", { name: "Cancel" }).click();
     await expect(page).toHaveURL(/\/books\/book-1$/);
+  });
+});
+
+test.describe("Books FILTER SORT AND URL PERSISTENCE", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/books");
+    await page.getByRole("button", { name: "Login" }).click();
+    // Wait for all 4 seed books to be visible
+    await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "テスト書籍2" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "テスト書籍3" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "テスト書籍4" })).toBeVisible();
+  });
+
+  // --- Filter tests ---
+
+  test("read filter: true shows only read books", async ({ page }) => {
+    const readFilter = page.getByTestId("filter-read");
+    await readFilter.getByRole("combobox").click();
+    await page.getByRole("option", { name: "true" }).click();
+
+    await expect(page.getByRole("link", { name: "テスト書籍2" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "テスト書籍4" })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "テスト書籍1" }),
+    ).not.toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "テスト書籍3" }),
+    ).not.toBeVisible();
+  });
+
+  test("owned filter: true shows only owned books", async ({ page }) => {
+    const ownedFilter = page.getByTestId("filter-owned");
+    await ownedFilter.getByRole("combobox").click();
+    await page.getByRole("option", { name: "true" }).click();
+
+    await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "テスト書籍2" })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "テスト書籍3" }),
+    ).not.toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "テスト書籍4" }),
+    ).not.toBeVisible();
+  });
+
+  test("format filter: Printed shows only printed books", async ({ page }) => {
+    const formatFilter = page.getByTestId("filter-format");
+    await formatFilter.getByRole("combobox").click();
+    await page.getByRole("option", { name: "Printed" }).click();
+
+    await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "テスト書籍2" }),
+    ).not.toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "テスト書籍3" }),
+    ).not.toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "テスト書籍4" }),
+    ).not.toBeVisible();
+  });
+
+  test("preset filter: Unread owned shows only book1 sorted by priority desc", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Preset filters" }).click();
+    await page
+      .getByRole("menuitem", { name: "Unread owned, order by priority" })
+      .click();
+
+    await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "テスト書籍2" }),
+    ).not.toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "テスト書籍3" }),
+    ).not.toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "テスト書籍4" }),
+    ).not.toBeVisible();
+  });
+
+  test("reset filter: clears all filters and shows all books", async ({
+    page,
+  }) => {
+    // Apply a filter first
+    const readFilter = page.getByTestId("filter-read");
+    await readFilter.getByRole("combobox").click();
+    await page.getByRole("option", { name: "true" }).click();
+    await expect(
+      page.getByRole("link", { name: "テスト書籍1" }),
+    ).not.toBeVisible();
+
+    // Reset
+    await page.getByRole("button", { name: "Reset filter" }).click();
+
+    await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "テスト書籍2" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "テスト書籍3" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "テスト書籍4" })).toBeVisible();
+  });
+
+  // --- URL persistence tests (verify state survives page reload) ---
+
+  test("filter persists on page reload", async ({ page }) => {
+    // Apply read=true filter
+    const readFilter = page.getByTestId("filter-read");
+    await readFilter.getByRole("combobox").click();
+    await page.getByRole("option", { name: "true" }).click();
+    await expect(
+      page.getByRole("link", { name: "テスト書籍1" }),
+    ).not.toBeVisible();
+
+    // Reload page — filter must survive via URL params
+    await page.reload();
+    await expect(page.getByRole("link", { name: "テスト書籍2" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "テスト書籍4" })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "テスト書籍1" }),
+    ).not.toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "テスト書籍3" }),
+    ).not.toBeVisible();
+  });
+
+  test("sort persists on page reload", async ({ page }) => {
+    // Click priority header to sort descending
+    await page
+      .getByRole("columnheader", { name: "優先度" })
+      .locator("span")
+      .first()
+      .click();
+
+    // Verify sort applied: book2 (priority=80) should appear before book4 (priority=10)
+    const rows = page.getByRole("row");
+    const book2Row = rows.filter({ hasText: "テスト書籍2" });
+    const book4Row = rows.filter({ hasText: "テスト書籍4" });
+    await expect(book2Row).toBeVisible();
+    await expect(book4Row).toBeVisible();
+
+    // Reload page — sort must survive via URL params
+    await page.reload();
+    await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
+
+    // Verify sort still applied after reload: priority desc means book2(80) before book4(10)
+    const rowsAfterReload = await page
+      .getByRole("row")
+      .filter({ hasText: /テスト書籍[1-4]/ })
+      .all();
+    expect(rowsAfterReload.length).toBe(4);
+    const texts = await Promise.all(
+      rowsAfterReload.map((r) => r.textContent()),
+    );
+    const book2Index = texts.findIndex((t) => t?.includes("テスト書籍2"));
+    const book1Index = texts.findIndex((t) => t?.includes("テスト書籍1"));
+    // book2 (priority=80) should come before book1 (priority=50)
+    expect(book2Index).toBeLessThan(book1Index);
+  });
+
+  test("reset clears filter URL params", async ({ page }) => {
+    // Apply a filter so URL gets params
+    const readFilter = page.getByTestId("filter-read");
+    await readFilter.getByRole("combobox").click();
+    await page.getByRole("option", { name: "true" }).click();
+    await expect(
+      page.getByRole("link", { name: "テスト書籍1" }),
+    ).not.toBeVisible();
+
+    // Reset
+    await page.getByRole("button", { name: "Reset filter" }).click();
+    await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
+
+    // URL should have no columnFilters param
+    const url = new URL(page.url());
+    expect(url.searchParams.has("columnFilters")).toBe(false);
+    expect(url.searchParams.has("sorting")).toBe(false);
   });
 });
 

--- a/e2e/mockStore.ts
+++ b/e2e/mockStore.ts
@@ -66,6 +66,28 @@ export class MockStore {
       format: "E_BOOK",
       store: "KINDLE",
     });
+
+    this.createBook({
+      title: "テスト書籍3",
+      authorIds: [author1.id],
+      isbn: "978-4-00-000003-4",
+      read: false,
+      owned: false,
+      priority: 30,
+      format: "UNKNOWN",
+      store: "UNKNOWN",
+    });
+
+    this.createBook({
+      title: "テスト書籍4",
+      authorIds: [author2.id],
+      isbn: "978-4-00-000004-1",
+      read: true,
+      owned: false,
+      priority: 10,
+      format: "E_BOOK",
+      store: "KINDLE",
+    });
   }
 
   createAuthor(name: string): Author {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "mantine-form-zod-resolver": "1.3.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
-        "tanstack-table-search-params": "0.12.1",
         "typescript": "5.9.3",
         "zod": "4.3.6"
       },
@@ -559,9 +558,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -579,9 +575,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -599,9 +592,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -619,9 +609,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -3177,9 +3164,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3197,9 +3181,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3217,9 +3198,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3237,9 +3215,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3257,9 +3232,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3277,9 +3249,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8485,9 +8454,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8509,9 +8475,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8533,9 +8496,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8557,9 +8517,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11024,16 +10981,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/tanstack-table-search-params": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/tanstack-table-search-params/-/tanstack-table-search-params-0.12.1.tgz",
-      "integrity": "sha512-63c32j3pWK6kYETPF6ZZsyNUnP6KH7SnQQUYGIttDso6KQTKuvJ683OXknfr0a+botmaZshcnUPs/whYe/LyTA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@tanstack/react-table": ">=8.21.3",
-        "react": ">=19.2.0"
       }
     },
     "node_modules/timeout-signal": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "mantine-form-zod-resolver": "1.3.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "tanstack-table-search-params": "0.12.1",
     "typescript": "5.9.3",
     "zod": "4.3.6"
   },

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.12.14'
+const PACKAGE_VERSION = '2.13.0'
 const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/src/features/books/BookList.test.tsx
+++ b/src/features/books/BookList.test.tsx
@@ -216,6 +216,10 @@ const changeSelect = (testId: string, value: string) => {
 };
 
 describe("BookList filters", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   test("shows all books initially", async () => {
     renderBookList();
     await waitFor(() => {
@@ -468,6 +472,10 @@ describe("BookList sorting", () => {
 });
 
 describe("BookList preset and reset", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   test("preset filter shows only unread owned books", async () => {
     renderBookList();
 

--- a/src/features/books/BookList.test.tsx
+++ b/src/features/books/BookList.test.tsx
@@ -1,7 +1,14 @@
 import "@testing-library/jest-dom";
 import { MantineProvider } from "@mantine/core";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { vi } from "vitest";
@@ -51,7 +58,7 @@ vi.mock("@mantine/core", async (importOriginal) => {
       value,
     }: {
       onChange?: (value: string | null) => void;
-      data: Array<{ value: string; label: string } | string>;
+      data: ({ value: string; label: string } | string)[];
       value?: string | null;
     }) => (
       <select
@@ -76,7 +83,7 @@ vi.mock("@mantine/core", async (importOriginal) => {
       disabled,
     }: {
       onChange?: (value: string[]) => void;
-      data: Array<{ value: string; label: string }>;
+      data: { value: string; label: string }[];
       value?: string[];
       disabled?: boolean;
       searchable?: boolean;
@@ -105,9 +112,9 @@ vi.mock("@mantine/core", async (importOriginal) => {
 
 beforeAll(() => {
   global.ResizeObserver = class ResizeObserver {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
   };
 
   HTMLElement.prototype.scrollIntoView = vi.fn();
@@ -202,7 +209,9 @@ const renderBookList = () =>
 /** Change the native <select> rendered inside the mocked Select component. */
 const changeSelect = (testId: string, value: string) => {
   const container = screen.getByTestId(testId);
-  const select = container.querySelector("select")!;
+  const select = container.querySelector("select");
+  if (!select)
+    throw new Error(`No <select> found inside [data-testid="${testId}"]`);
   fireEvent.change(select, { target: { value } });
 };
 
@@ -225,12 +234,12 @@ describe("BookList filters", () => {
       expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
     });
 
-    const titleInput = within(
-      screen.getByTestId("filter-title"),
-    ).getByRole("textbox");
+    const titleInput = within(screen.getByTestId("filter-title")).getByRole(
+      "textbox",
+    );
     fireEvent.change(titleInput, { target: { value: "書籍1" } });
 
-    await act(async () => {
+    act(() => {
       vi.advanceTimersByTime(1100);
     });
 
@@ -250,12 +259,12 @@ describe("BookList filters", () => {
       expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
     });
 
-    const isbnInput = within(
-      screen.getByTestId("filter-isbn"),
-    ).getByRole("textbox");
+    const isbnInput = within(screen.getByTestId("filter-isbn")).getByRole(
+      "textbox",
+    );
     fireEvent.change(isbnInput, { target: { value: "000002" } });
 
-    await act(async () => {
+    act(() => {
       vi.advanceTimersByTime(1100);
     });
 
@@ -377,7 +386,8 @@ describe("BookList filters", () => {
     });
 
     const authorsContainer = screen.getByTestId("filter-authors");
-    const authorsSelect = authorsContainer.querySelector("select")!;
+    const authorsSelect = authorsContainer.querySelector("select");
+    if (!authorsSelect) throw new Error("No <select> found in filter-authors");
     await userEvent.selectOptions(authorsSelect, ["author-1"]);
 
     await waitFor(() => {
@@ -392,10 +402,13 @@ describe("BookList filters", () => {
 describe("BookList sorting", () => {
   // The sort onClick is on the inner Group div, not the <th>.
   // Clicking the text element itself bubbles up to the Group handler.
-  const getHeaderText = (name: string) =>
-    screen
+  const getHeaderText = (name: string) => {
+    const el = screen
       .getAllByText(name)
-      .find((el) => el.closest("thead") !== null) as HTMLElement;
+      .find((e) => e.closest("thead") !== null);
+    if (!el) throw new Error(`Header text "${name}" not found in thead`);
+    return el;
+  };
 
   test("sort priority descending puts highest priority first", async () => {
     const user = userEvent.setup();
@@ -490,12 +503,12 @@ describe("BookList preset and reset", () => {
       expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
     });
 
-    const titleInput = within(
-      screen.getByTestId("filter-title"),
-    ).getByRole("textbox");
+    const titleInput = within(screen.getByTestId("filter-title")).getByRole(
+      "textbox",
+    );
     fireEvent.change(titleInput, { target: { value: "書籍1" } });
 
-    await act(async () => {
+    act(() => {
       vi.advanceTimersByTime(1100);
     });
 
@@ -521,12 +534,12 @@ describe("BookList preset and reset", () => {
       expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
     });
 
-    const titleInput = within(
-      screen.getByTestId("filter-title"),
-    ).getByRole("textbox");
+    const titleInput = within(screen.getByTestId("filter-title")).getByRole(
+      "textbox",
+    );
     fireEvent.change(titleInput, { target: { value: "書籍1" } });
 
-    await act(async () => {
+    act(() => {
       vi.advanceTimersByTime(1100);
     });
 

--- a/src/features/books/BookList.test.tsx
+++ b/src/features/books/BookList.test.tsx
@@ -1,0 +1,543 @@
+import "@testing-library/jest-dom";
+import { MantineProvider } from "@mantine/core";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { vi } from "vitest";
+import { BookList } from "./BookList";
+import type { Book } from "./entity/Book";
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@tanstack/react-router")>();
+  return {
+    ...actual,
+    getRouteApi: () => ({
+      useSearch: () => ({}),
+      useNavigate: () => vi.fn().mockResolvedValue(undefined),
+    }),
+  };
+});
+
+vi.mock("../../compoments/hooks/useAuthors", () => ({
+  useAuthors: () => ({
+    data: {
+      authors: [
+        { id: "author-1", name: "著者1" },
+        { id: "author-2", name: "著者2" },
+      ],
+    },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("../../compoments/mantineTsr", () => ({
+  Link: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+
+// Replace Mantine's Select / MultiSelect with native HTML elements to avoid
+// Floating UI positioning issues in jsdom.
+vi.mock("@mantine/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mantine/core")>();
+  return {
+    ...actual,
+    Select: ({
+      onChange,
+      data,
+      value,
+    }: {
+      onChange?: (value: string | null) => void;
+      data: Array<{ value: string; label: string } | string>;
+      value?: string | null;
+    }) => (
+      <select
+        value={value ?? ""}
+        onChange={(e) => onChange?.(e.target.value || null)}
+      >
+        {data.map((item) => {
+          const v = typeof item === "string" ? item : item.value;
+          const l = typeof item === "string" ? item : item.label;
+          return (
+            <option key={v} value={v}>
+              {l}
+            </option>
+          );
+        })}
+      </select>
+    ),
+    MultiSelect: ({
+      onChange,
+      data,
+      value,
+      disabled,
+    }: {
+      onChange?: (value: string[]) => void;
+      data: Array<{ value: string; label: string }>;
+      value?: string[];
+      disabled?: boolean;
+      searchable?: boolean;
+      rightSection?: React.ReactNode;
+    }) => (
+      <select
+        multiple
+        disabled={disabled}
+        value={value ?? []}
+        onChange={(e) => {
+          const selected = Array.from(e.target.selectedOptions).map(
+            (o) => o.value,
+          );
+          onChange?.(selected);
+        }}
+      >
+        {data.map((item) => (
+          <option key={item.value} value={item.value}>
+            {item.label}
+          </option>
+        ))}
+      </select>
+    ),
+  };
+});
+
+beforeAll(() => {
+  global.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+
+  HTMLElement.prototype.scrollIntoView = vi.fn();
+
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+const now = new Date();
+
+const testBooks: Book[] = [
+  {
+    id: "book-1",
+    title: "テスト書籍1",
+    authors: [{ id: "author-1", name: "著者1" }],
+    isbn: "978-4-00-000001-0",
+    read: false,
+    owned: true,
+    priority: 50,
+    format: "PRINTED",
+    store: "UNKNOWN",
+    createdAt: now,
+    updatedAt: now,
+  },
+  {
+    id: "book-2",
+    title: "テスト書籍2",
+    authors: [{ id: "author-2", name: "著者2" }],
+    isbn: "978-4-00-000002-7",
+    read: true,
+    owned: true,
+    priority: 80,
+    format: "E_BOOK",
+    store: "KINDLE",
+    createdAt: now,
+    updatedAt: now,
+  },
+  {
+    id: "book-3",
+    title: "テスト書籍3",
+    authors: [{ id: "author-1", name: "著者1" }],
+    isbn: "978-4-00-000003-4",
+    read: false,
+    owned: false,
+    priority: 30,
+    format: "UNKNOWN",
+    store: "UNKNOWN",
+    createdAt: now,
+    updatedAt: now,
+  },
+  {
+    id: "book-4",
+    title: "テスト書籍4",
+    authors: [{ id: "author-2", name: "著者2" }],
+    isbn: "978-4-00-000004-1",
+    read: true,
+    owned: false,
+    priority: 10,
+    format: "E_BOOK",
+    store: "KINDLE",
+    createdAt: now,
+    updatedAt: now,
+  },
+];
+
+const createWrapper = (): React.FC<{ children: React.ReactNode }> => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      <MantineProvider>{children}</MantineProvider>
+    </QueryClientProvider>
+  );
+  return wrapper;
+};
+
+const renderBookList = () =>
+  render(<BookList list={testBooks} />, { wrapper: createWrapper() });
+
+/** Change the native <select> rendered inside the mocked Select component. */
+const changeSelect = (testId: string, value: string) => {
+  const container = screen.getByTestId(testId);
+  const select = container.querySelector("select")!;
+  fireEvent.change(select, { target: { value } });
+};
+
+describe("BookList filters", () => {
+  test("shows all books initially", async () => {
+    renderBookList();
+    await waitFor(() => {
+      expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+    });
+    expect(screen.getByText("テスト書籍2")).toBeInTheDocument();
+    expect(screen.getByText("テスト書籍3")).toBeInTheDocument();
+    expect(screen.getByText("テスト書籍4")).toBeInTheDocument();
+  });
+
+  test("title string filter shows only matching books", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    renderBookList();
+
+    await waitFor(() => {
+      expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+    });
+
+    const titleInput = within(
+      screen.getByTestId("filter-title"),
+    ).getByRole("textbox");
+    fireEvent.change(titleInput, { target: { value: "書籍1" } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1100);
+    });
+
+    expect(screen.queryByText("テスト書籍2")).not.toBeInTheDocument();
+    expect(screen.queryByText("テスト書籍3")).not.toBeInTheDocument();
+    expect(screen.queryByText("テスト書籍4")).not.toBeInTheDocument();
+    expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  test("ISBN string filter shows only matching books", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    renderBookList();
+
+    await waitFor(() => {
+      expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+    });
+
+    const isbnInput = within(
+      screen.getByTestId("filter-isbn"),
+    ).getByRole("textbox");
+    fireEvent.change(isbnInput, { target: { value: "000002" } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1100);
+    });
+
+    expect(screen.queryByText("テスト書籍1")).not.toBeInTheDocument();
+    expect(screen.queryByText("テスト書籍3")).not.toBeInTheDocument();
+    expect(screen.queryByText("テスト書籍4")).not.toBeInTheDocument();
+    expect(screen.getByText("テスト書籍2")).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  test("read filter = true shows only read books", async () => {
+    renderBookList();
+
+    await waitFor(() => {
+      expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+    });
+
+    changeSelect("filter-read", "true");
+
+    await waitFor(() => {
+      expect(screen.queryByText("テスト書籍1")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText("テスト書籍3")).not.toBeInTheDocument();
+    expect(screen.getByText("テスト書籍2")).toBeInTheDocument();
+    expect(screen.getByText("テスト書籍4")).toBeInTheDocument();
+  });
+
+  test("read filter = false shows only unread books", async () => {
+    renderBookList();
+
+    await waitFor(() => {
+      expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+    });
+
+    changeSelect("filter-read", "false");
+
+    await waitFor(() => {
+      expect(screen.queryByText("テスト書籍2")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText("テスト書籍4")).not.toBeInTheDocument();
+    expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+    expect(screen.getByText("テスト書籍3")).toBeInTheDocument();
+  });
+
+  test("owned filter = true shows only owned books", async () => {
+    renderBookList();
+
+    await waitFor(() => {
+      expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+    });
+
+    changeSelect("filter-owned", "true");
+
+    await waitFor(() => {
+      expect(screen.queryByText("テスト書籍3")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText("テスト書籍4")).not.toBeInTheDocument();
+    expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+    expect(screen.getByText("テスト書籍2")).toBeInTheDocument();
+  });
+
+  test("format filter = PRINTED shows only printed books", async () => {
+    renderBookList();
+
+    await waitFor(() => {
+      expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+    });
+
+    changeSelect("filter-format", "PRINTED");
+
+    await waitFor(() => {
+      expect(screen.queryByText("テスト書籍2")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText("テスト書籍3")).not.toBeInTheDocument();
+    expect(screen.queryByText("テスト書籍4")).not.toBeInTheDocument();
+    expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+  });
+
+  test("format filter = E_BOOK shows only eBook books", async () => {
+    renderBookList();
+
+    await waitFor(() => {
+      expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+    });
+
+    changeSelect("filter-format", "E_BOOK");
+
+    await waitFor(() => {
+      expect(screen.queryByText("テスト書籍1")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText("テスト書籍3")).not.toBeInTheDocument();
+    expect(screen.getByText("テスト書籍2")).toBeInTheDocument();
+    expect(screen.getByText("テスト書籍4")).toBeInTheDocument();
+  });
+
+  test("store filter = KINDLE shows only Kindle books", async () => {
+    renderBookList();
+
+    await waitFor(() => {
+      expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+    });
+
+    changeSelect("filter-store", "KINDLE");
+
+    await waitFor(() => {
+      expect(screen.queryByText("テスト書籍1")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText("テスト書籍3")).not.toBeInTheDocument();
+    expect(screen.getByText("テスト書籍2")).toBeInTheDocument();
+    expect(screen.getByText("テスト書籍4")).toBeInTheDocument();
+  });
+
+  test("authors filter shows only books by selected author", async () => {
+    renderBookList();
+
+    await waitFor(() => {
+      expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+    });
+
+    const authorsContainer = screen.getByTestId("filter-authors");
+    const authorsSelect = authorsContainer.querySelector("select")!;
+    await userEvent.selectOptions(authorsSelect, ["author-1"]);
+
+    await waitFor(() => {
+      expect(screen.queryByText("テスト書籍2")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText("テスト書籍4")).not.toBeInTheDocument();
+    expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+    expect(screen.getByText("テスト書籍3")).toBeInTheDocument();
+  });
+});
+
+describe("BookList sorting", () => {
+  // The sort onClick is on the inner Group div, not the <th>.
+  // Clicking the text element itself bubbles up to the Group handler.
+  const getHeaderText = (name: string) =>
+    screen
+      .getAllByText(name)
+      .find((el) => el.closest("thead") !== null) as HTMLElement;
+
+  test("sort priority descending puts highest priority first", async () => {
+    const user = userEvent.setup();
+    renderBookList();
+
+    await waitFor(() => {
+      expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+    });
+
+    await user.click(getHeaderText("優先度"));
+
+    await waitFor(() => {
+      const bodyRows = screen
+        .getAllByRole("row")
+        .filter((r) => r.closest("tbody"));
+      expect(within(bodyRows[0]).getByText("テスト書籍2")).toBeInTheDocument();
+    });
+  });
+
+  test("sort priority ascending puts lowest priority first", async () => {
+    const user = userEvent.setup();
+    renderBookList();
+
+    await waitFor(() => {
+      expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+    });
+
+    const priorityText = getHeaderText("優先度");
+    await user.click(priorityText); // → desc
+    await user.click(priorityText); // → asc
+
+    await waitFor(() => {
+      const bodyRows = screen
+        .getAllByRole("row")
+        .filter((r) => r.closest("tbody"));
+      expect(within(bodyRows[0]).getByText("テスト書籍4")).toBeInTheDocument();
+    });
+  });
+
+  test("sort title ascending puts テスト書籍1 first", async () => {
+    const user = userEvent.setup();
+    renderBookList();
+
+    await waitFor(() => {
+      expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+    });
+
+    await user.click(getHeaderText("書名"));
+
+    await waitFor(() => {
+      const bodyRows = screen
+        .getAllByRole("row")
+        .filter((r) => r.closest("tbody"));
+      expect(within(bodyRows[0]).getByText("テスト書籍1")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("BookList preset and reset", () => {
+  test("preset filter shows only unread owned books", async () => {
+    renderBookList();
+
+    await waitFor(() => {
+      expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+    });
+
+    // fireEvent opens the Mantine Menu reliably in jsdom (user.click fires
+    // pointer events that the Menu's internal handler may not catch).
+    fireEvent.click(screen.getByRole("button", { name: "Preset filters" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Unread owned, order by priority"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Unread owned, order by priority"));
+
+    await waitFor(() => {
+      expect(screen.queryByText("テスト書籍2")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText("テスト書籍3")).not.toBeInTheDocument();
+    expect(screen.queryByText("テスト書籍4")).not.toBeInTheDocument();
+    expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+  });
+
+  test("reset filter restores all books", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    renderBookList();
+
+    await waitFor(() => {
+      expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+    });
+
+    const titleInput = within(
+      screen.getByTestId("filter-title"),
+    ).getByRole("textbox");
+    fireEvent.change(titleInput, { target: { value: "書籍1" } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1100);
+    });
+
+    expect(screen.queryByText("テスト書籍2")).not.toBeInTheDocument();
+
+    vi.useRealTimers();
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset filter" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("テスト書籍2")).toBeInTheDocument();
+    });
+    expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+    expect(screen.getByText("テスト書籍3")).toBeInTheDocument();
+    expect(screen.getByText("テスト書籍4")).toBeInTheDocument();
+  });
+
+  test("reset filter clears the title input", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    renderBookList();
+
+    await waitFor(() => {
+      expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
+    });
+
+    const titleInput = within(
+      screen.getByTestId("filter-title"),
+    ).getByRole("textbox");
+    fireEvent.change(titleInput, { target: { value: "書籍1" } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1100);
+    });
+
+    expect(screen.queryByText("テスト書籍2")).not.toBeInTheDocument();
+
+    vi.useRealTimers();
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset filter" }));
+
+    await waitFor(() => {
+      expect(titleInput).toHaveValue("");
+    });
+  });
+});

--- a/src/features/books/BookList.test.tsx
+++ b/src/features/books/BookList.test.tsx
@@ -46,70 +46,6 @@ vi.mock("../../compoments/mantineTsr", () => ({
   ),
 }));
 
-// Replace Mantine's Select / MultiSelect with native HTML elements to avoid
-// Floating UI positioning issues in jsdom.
-vi.mock("@mantine/core", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@mantine/core")>();
-  return {
-    ...actual,
-    Select: ({
-      onChange,
-      data,
-      value,
-    }: {
-      onChange?: (value: string | null) => void;
-      data: ({ value: string; label: string } | string)[];
-      value?: string | null;
-    }) => (
-      <select
-        value={value ?? ""}
-        onChange={(e) => onChange?.(e.target.value || null)}
-      >
-        {data.map((item) => {
-          const v = typeof item === "string" ? item : item.value;
-          const l = typeof item === "string" ? item : item.label;
-          return (
-            <option key={v} value={v}>
-              {l}
-            </option>
-          );
-        })}
-      </select>
-    ),
-    MultiSelect: ({
-      onChange,
-      data,
-      value,
-      disabled,
-    }: {
-      onChange?: (value: string[]) => void;
-      data: { value: string; label: string }[];
-      value?: string[];
-      disabled?: boolean;
-      searchable?: boolean;
-      rightSection?: React.ReactNode;
-    }) => (
-      <select
-        multiple
-        disabled={disabled}
-        value={value ?? []}
-        onChange={(e) => {
-          const selected = Array.from(e.target.selectedOptions).map(
-            (o) => o.value,
-          );
-          onChange?.(selected);
-        }}
-      >
-        {data.map((item) => (
-          <option key={item.value} value={item.value}>
-            {item.label}
-          </option>
-        ))}
-      </select>
-    ),
-  };
-});
-
 beforeAll(() => {
   global.ResizeObserver = class ResizeObserver {
     observe = vi.fn();
@@ -197,7 +133,7 @@ const createWrapper = (): React.FC<{ children: React.ReactNode }> => {
   });
   const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
     <QueryClientProvider client={queryClient}>
-      <MantineProvider>{children}</MantineProvider>
+      <MantineProvider env="test">{children}</MantineProvider>
     </QueryClientProvider>
   );
   return wrapper;
@@ -205,15 +141,6 @@ const createWrapper = (): React.FC<{ children: React.ReactNode }> => {
 
 const renderBookList = () =>
   render(<BookList list={testBooks} />, { wrapper: createWrapper() });
-
-/** Change the native <select> rendered inside the mocked Select component. */
-const changeSelect = (testId: string, value: string) => {
-  const container = screen.getByTestId(testId);
-  const select = container.querySelector("select");
-  if (!select)
-    throw new Error(`No <select> found inside [data-testid="${testId}"]`);
-  fireEvent.change(select, { target: { value } });
-};
 
 describe("BookList filters", () => {
   afterEach(() => {
@@ -287,7 +214,10 @@ describe("BookList filters", () => {
       expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
     });
 
-    changeSelect("filter-read", "true");
+    await userEvent.click(
+      within(screen.getByTestId("filter-read")).getByRole("textbox"),
+    );
+    await userEvent.click(screen.getByRole("option", { name: "true" }));
 
     await waitFor(() => {
       expect(screen.queryByText("テスト書籍1")).not.toBeInTheDocument();
@@ -304,7 +234,10 @@ describe("BookList filters", () => {
       expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
     });
 
-    changeSelect("filter-read", "false");
+    await userEvent.click(
+      within(screen.getByTestId("filter-read")).getByRole("textbox"),
+    );
+    await userEvent.click(screen.getByRole("option", { name: "false" }));
 
     await waitFor(() => {
       expect(screen.queryByText("テスト書籍2")).not.toBeInTheDocument();
@@ -321,7 +254,10 @@ describe("BookList filters", () => {
       expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
     });
 
-    changeSelect("filter-owned", "true");
+    await userEvent.click(
+      within(screen.getByTestId("filter-owned")).getByRole("textbox"),
+    );
+    await userEvent.click(screen.getByRole("option", { name: "true" }));
 
     await waitFor(() => {
       expect(screen.queryByText("テスト書籍3")).not.toBeInTheDocument();
@@ -338,7 +274,10 @@ describe("BookList filters", () => {
       expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
     });
 
-    changeSelect("filter-format", "PRINTED");
+    await userEvent.click(
+      within(screen.getByTestId("filter-format")).getByRole("textbox"),
+    );
+    await userEvent.click(screen.getByRole("option", { name: "Printed" }));
 
     await waitFor(() => {
       expect(screen.queryByText("テスト書籍2")).not.toBeInTheDocument();
@@ -355,7 +294,10 @@ describe("BookList filters", () => {
       expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
     });
 
-    changeSelect("filter-format", "E_BOOK");
+    await userEvent.click(
+      within(screen.getByTestId("filter-format")).getByRole("textbox"),
+    );
+    await userEvent.click(screen.getByRole("option", { name: "eBook" }));
 
     await waitFor(() => {
       expect(screen.queryByText("テスト書籍1")).not.toBeInTheDocument();
@@ -372,7 +314,10 @@ describe("BookList filters", () => {
       expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
     });
 
-    changeSelect("filter-store", "KINDLE");
+    await userEvent.click(
+      within(screen.getByTestId("filter-store")).getByRole("textbox"),
+    );
+    await userEvent.click(screen.getByRole("option", { name: "Kindle" }));
 
     await waitFor(() => {
       expect(screen.queryByText("テスト書籍1")).not.toBeInTheDocument();
@@ -389,10 +334,10 @@ describe("BookList filters", () => {
       expect(screen.getByText("テスト書籍1")).toBeInTheDocument();
     });
 
-    const authorsContainer = screen.getByTestId("filter-authors");
-    const authorsSelect = authorsContainer.querySelector("select");
-    if (!authorsSelect) throw new Error("No <select> found in filter-authors");
-    await userEvent.selectOptions(authorsSelect, ["author-1"]);
+    await userEvent.click(
+      within(screen.getByTestId("filter-authors")).getByRole("textbox"),
+    );
+    await userEvent.click(screen.getByRole("option", { name: "著者1" }));
 
     await waitFor(() => {
       expect(screen.queryByText("テスト書籍2")).not.toBeInTheDocument();

--- a/src/features/books/BookList.tsx
+++ b/src/features/books/BookList.tsx
@@ -190,12 +190,6 @@ export const BookList: React.FC<BookListProps> = ({ list }) => {
     pageSize: search.pageSize ?? 20,
   });
 
-  // Re-sync local state when URL changes externally (browser back/forward).
-  // TanStack Router returns a new array reference on every render even when the
-  // content is identical, so reference equality would cause infinite updates.
-  // JSON.stringify is used for value-based comparison instead.
-  // The filter values are always JSON-serializable primitives (string, boolean,
-  // number, string[]), so JSON.stringify behaves deterministically here.
   const serializedColumnFilters = JSON.stringify(search.columnFilters ?? []);
   const serializedSorting = JSON.stringify(search.sorting ?? []);
 

--- a/src/features/books/BookList.tsx
+++ b/src/features/books/BookList.tsx
@@ -15,6 +15,7 @@ import {
 import {
   Column,
   ColumnDef,
+  ColumnFiltersState,
   createColumnHelper,
   FilterFn,
   flexRender,
@@ -22,7 +23,10 @@ import {
   getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
+  OnChangeFn,
+  PaginationState,
   RowData,
+  SortingState,
   useReactTable,
 } from "@tanstack/react-table";
 import dayjs from "dayjs";
@@ -33,8 +37,7 @@ import {
   IconSortDescending,
 } from "@tabler/icons-react";
 import { getRouteApi } from "@tanstack/react-router";
-import React, { ReactNode } from "react";
-import { useTableSearchParams } from "tanstack-table-search-params";
+import React, { ReactNode, useEffect, useState } from "react";
 import { Link } from "../../compoments/mantineTsr";
 import { ShowBoolean } from "../../compoments/utils/ShowBoolean";
 import { Author } from "./entity/Author";
@@ -174,30 +177,81 @@ const SortIcon: React.FC<SortIconProps> = ({ isSorted }) => {
 export const BookList: React.FC<BookListProps> = ({ list }) => {
   const routeApi = getRouteApi("/books/");
   const navigate = routeApi.useNavigate();
-  const query = routeApi.useSearch();
+  const search = routeApi.useSearch();
 
-  const stateAndOnChanges = useTableSearchParams({
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    replace: async (url) => {
-      const searchParams = new URLSearchParams(url.split("?")[1]);
-      await navigate({
-        search: (prev) => {
-          // navigateが非同期の関係上、差分更新にしないと反映されない場合がある
-          // TODO: しかしこれにより、reset filterが動かなくなってしまう
-          return { ...prev, ...Object.fromEntries(searchParams.entries()) };
-        },
-        replace: true,
-      });
-    },
-    query,
-    pathname: "/books",
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(
+    (search.columnFilters ?? []) as ColumnFiltersState,
+  );
+  const [sorting, setSorting] = useState<SortingState>(
+    (search.sorting ?? []) as SortingState,
+  );
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: search.pageIndex ?? 0,
+    pageSize: search.pageSize ?? 20,
   });
+
+  // Re-sync local state when URL changes externally (browser back/forward)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    setColumnFilters((search.columnFilters ?? []) as ColumnFiltersState);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(search.columnFilters)]);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    setSorting((search.sorting ?? []) as SortingState);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(search.sorting)]);
+
+  useEffect(() => {
+    setPagination({
+      pageIndex: search.pageIndex ?? 0,
+      pageSize: search.pageSize ?? 20,
+    });
+  }, [search.pageIndex, search.pageSize]);
+
+  const handleColumnFiltersChange: OnChangeFn<ColumnFiltersState> = (
+    updater,
+  ) => {
+    const next =
+      typeof updater === "function" ? updater(columnFilters) : updater;
+    setColumnFilters(next);
+    void navigate({
+      search: (prev) => ({ ...prev, columnFilters: next, pageIndex: 0 }),
+      replace: true,
+    });
+  };
+
+  const handleSortingChange: OnChangeFn<SortingState> = (updater) => {
+    const next = typeof updater === "function" ? updater(sorting) : updater;
+    setSorting(next);
+    void navigate({
+      search: (prev) => ({ ...prev, sorting: next }),
+      replace: true,
+    });
+  };
+
+  const handlePaginationChange: OnChangeFn<PaginationState> = (updater) => {
+    const next =
+      typeof updater === "function" ? updater(pagination) : updater;
+    setPagination(next);
+    void navigate({
+      search: (prev) => ({
+        ...prev,
+        pageIndex: next.pageIndex,
+        pageSize: next.pageSize,
+      }),
+      replace: true,
+    });
+  };
 
   const table = useReactTable({
     data: list,
     columns,
-    initialState: { pagination: { pageSize: 20 } },
-    ...stateAndOnChanges,
+    state: { columnFilters, sorting, pagination },
+    onColumnFiltersChange: handleColumnFiltersChange,
+    onSortingChange: handleSortingChange,
+    onPaginationChange: handlePaginationChange,
 
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
@@ -256,10 +310,11 @@ export const BookList: React.FC<BookListProps> = ({ list }) => {
           </Menu.Dropdown>
         </Menu>
         <Button
-          onClick={async () => {
-            // table.resetColumnFilters();
-            // 上記だと動かないので、暫定対応
-            await navigate({ search: {}, replace: true });
+          onClick={() => {
+            setColumnFilters([]);
+            setSorting([]);
+            setPagination({ pageIndex: 0, pageSize: 20 });
+            void navigate({ search: {}, replace: true });
           }}
           color="red"
         >

--- a/src/features/books/BookList.tsx
+++ b/src/features/books/BookList.tsx
@@ -179,28 +179,27 @@ export const BookList: React.FC<BookListProps> = ({ list }) => {
   const navigate = routeApi.useNavigate();
   const search = routeApi.useSearch();
 
-  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(
+  const [columnFilters, setColumnFilters] = useState(
     (search.columnFilters ?? []) as ColumnFiltersState,
   );
-  const [sorting, setSorting] = useState<SortingState>(
+  const [sorting, setSorting] = useState(
     (search.sorting ?? []) as SortingState,
   );
-  const [pagination, setPagination] = useState<PaginationState>({
+  const [pagination, setPagination] = useState({
     pageIndex: search.pageIndex ?? 0,
     pageSize: search.pageSize ?? 20,
   });
 
   // Re-sync local state when URL changes externally (browser back/forward)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+
   useEffect(() => {
     setColumnFilters((search.columnFilters ?? []) as ColumnFiltersState);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(search.columnFilters)]);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     setSorting((search.sorting ?? []) as SortingState);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(search.sorting)]);
 
   useEffect(() => {
@@ -232,8 +231,7 @@ export const BookList: React.FC<BookListProps> = ({ list }) => {
   };
 
   const handlePaginationChange: OnChangeFn<PaginationState> = (updater) => {
-    const next =
-      typeof updater === "function" ? updater(pagination) : updater;
+    const next = typeof updater === "function" ? updater(pagination) : updater;
     setPagination(next);
     void navigate({
       search: (prev) => ({

--- a/src/features/books/BookList.tsx
+++ b/src/features/books/BookList.tsx
@@ -196,16 +196,16 @@ export const BookList: React.FC<BookListProps> = ({ list }) => {
   // JSON.stringify is used for value-based comparison instead.
   // The filter values are always JSON-serializable primitives (string, boolean,
   // number, string[]), so JSON.stringify behaves deterministically here.
+  const serializedColumnFilters = JSON.stringify(search.columnFilters ?? []);
+  const serializedSorting = JSON.stringify(search.sorting ?? []);
 
   useEffect(() => {
-    setColumnFilters((search.columnFilters ?? []) as ColumnFiltersState);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(search.columnFilters)]);
+    setColumnFilters(JSON.parse(serializedColumnFilters) as ColumnFiltersState);
+  }, [serializedColumnFilters]);
 
   useEffect(() => {
-    setSorting((search.sorting ?? []) as SortingState);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(search.sorting)]);
+    setSorting(JSON.parse(serializedSorting) as SortingState);
+  }, [serializedSorting]);
 
   useEffect(() => {
     setPagination({

--- a/src/features/books/BookList.tsx
+++ b/src/features/books/BookList.tsx
@@ -215,6 +215,7 @@ export const BookList: React.FC<BookListProps> = ({ list }) => {
     const next =
       typeof updater === "function" ? updater(columnFilters) : updater;
     setColumnFilters(next);
+    if (JSON.stringify(next) === JSON.stringify(columnFilters)) return;
     void navigate({
       search: (prev) => ({ ...prev, columnFilters: next, pageIndex: 0 }),
       replace: true,

--- a/src/features/books/BookList.tsx
+++ b/src/features/books/BookList.tsx
@@ -190,7 +190,12 @@ export const BookList: React.FC<BookListProps> = ({ list }) => {
     pageSize: search.pageSize ?? 20,
   });
 
-  // Re-sync local state when URL changes externally (browser back/forward)
+  // Re-sync local state when URL changes externally (browser back/forward).
+  // TanStack Router returns a new array reference on every render even when the
+  // content is identical, so reference equality would cause infinite updates.
+  // JSON.stringify is used for value-based comparison instead.
+  // The filter values are always JSON-serializable primitives (string, boolean,
+  // number, string[]), so JSON.stringify behaves deterministically here.
 
   useEffect(() => {
     setColumnFilters((search.columnFilters ?? []) as ColumnFiltersState);

--- a/src/features/books/BookList.tsx
+++ b/src/features/books/BookList.tsx
@@ -72,6 +72,8 @@ const authorsFilter: FilterFn<Book> = (
 
 const formatDate = (date: Date) => dayjs(date).format("YYYY/MM/DD HH:mm Z");
 
+const DEFAULT_PAGE_SIZE = 20;
+
 const columnHelper = createColumnHelper<Book>();
 
 const columns = [
@@ -187,24 +189,28 @@ export const BookList: React.FC<BookListProps> = ({ list }) => {
   );
   const [pagination, setPagination] = useState({
     pageIndex: search.pageIndex ?? 0,
-    pageSize: search.pageSize ?? 20,
+    pageSize: search.pageSize ?? DEFAULT_PAGE_SIZE,
   });
 
   const serializedColumnFilters = JSON.stringify(search.columnFilters ?? []);
   const serializedSorting = JSON.stringify(search.sorting ?? []);
 
   useEffect(() => {
-    setColumnFilters(JSON.parse(serializedColumnFilters) as ColumnFiltersState);
+    setColumnFilters((search.columnFilters ?? []) as ColumnFiltersState);
+    // serializedColumnFilters is the stable dep; search.columnFilters is the current value.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [serializedColumnFilters]);
 
   useEffect(() => {
-    setSorting(JSON.parse(serializedSorting) as SortingState);
+    setSorting((search.sorting ?? []) as SortingState);
+    // serializedSorting is the stable dep; search.sorting is the current value.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [serializedSorting]);
 
   useEffect(() => {
     setPagination({
       pageIndex: search.pageIndex ?? 0,
-      pageSize: search.pageSize ?? 20,
+      pageSize: search.pageSize ?? DEFAULT_PAGE_SIZE,
     });
   }, [search.pageIndex, search.pageSize]);
 
@@ -224,6 +230,7 @@ export const BookList: React.FC<BookListProps> = ({ list }) => {
   const handleSortingChange: OnChangeFn<SortingState> = (updater) => {
     const next = typeof updater === "function" ? updater(sorting) : updater;
     setSorting(next);
+    if (JSON.stringify(next) === JSON.stringify(sorting)) return;
     void navigate({
       search: (prev) => ({ ...prev, sorting: next }),
       replace: true,
@@ -316,7 +323,7 @@ export const BookList: React.FC<BookListProps> = ({ list }) => {
           onClick={() => {
             setColumnFilters([]);
             setSorting([]);
-            setPagination({ pageIndex: 0, pageSize: 20 });
+            setPagination({ pageIndex: 0, pageSize: DEFAULT_PAGE_SIZE });
             void navigate({ search: {}, replace: true });
           }}
           color="red"

--- a/src/features/books/BookList.tsx
+++ b/src/features/books/BookList.tsx
@@ -234,6 +234,11 @@ export const BookList: React.FC<BookListProps> = ({ list }) => {
   const handlePaginationChange: OnChangeFn<PaginationState> = (updater) => {
     const next = typeof updater === "function" ? updater(pagination) : updater;
     setPagination(next);
+    if (
+      next.pageIndex === pagination.pageIndex &&
+      next.pageSize === pagination.pageSize
+    )
+      return;
     void navigate({
       search: (prev) => ({
         ...prev,

--- a/src/features/books/Filter.tsx
+++ b/src/features/books/Filter.tsx
@@ -13,18 +13,21 @@ type FilterProps<TData, TValue> = {
 export const Filter = <TData, TValue>({
   column,
 }: FilterProps<TData, TValue>): React.JSX.Element => {
-  switch (column.columnDef.meta?.filterType) {
-    case "string":
-      return <StringFilter column={column} />;
-    case "boolean":
-      return <BooleanFilter column={column} />;
-    case "format":
-      return <FormatFilter column={column} />;
-    case "store":
-      return <StoreFilter column={column} />;
-    case "authors":
-      return <AuthorsFilter column={column} />;
-    default:
-      return <></>;
-  }
+  const inner = (() => {
+    switch (column.columnDef.meta?.filterType) {
+      case "string":
+        return <StringFilter column={column} />;
+      case "boolean":
+        return <BooleanFilter column={column} />;
+      case "format":
+        return <FormatFilter column={column} />;
+      case "store":
+        return <StoreFilter column={column} />;
+      case "authors":
+        return <AuthorsFilter column={column} />;
+      default:
+        return <></>;
+    }
+  })();
+  return <div data-testid={`filter-${column.id}`}>{inner}</div>;
 };

--- a/src/features/books/StringFilter.tsx
+++ b/src/features/books/StringFilter.tsx
@@ -23,9 +23,7 @@ export const StringFilter = <TData, TValue>({
 
   const filterValue = column.getFilterValue();
   useEffect(() => {
-    if (filterValue === undefined) {
-      setValue("");
-    }
+    setValue((filterValue as string | undefined) ?? "");
   }, [filterValue]);
 
   return (

--- a/src/features/books/StringFilter.tsx
+++ b/src/features/books/StringFilter.tsx
@@ -1,6 +1,6 @@
 import { TextInput } from "@mantine/core";
 import { Column } from "@tanstack/react-table";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useDebouncedEffect } from "../../compoments/hooks/useDebouncedEffect";
 
 export type StringFilterProps<TData, TValue> = {
@@ -20,6 +20,13 @@ export const StringFilter = <TData, TValue>({
     [value],
     1000,
   );
+
+  const filterValue = column.getFilterValue();
+  useEffect(() => {
+    if (filterValue === undefined) {
+      setValue("");
+    }
+  }, [filterValue]);
 
   return (
     <TextInput

--- a/src/routes/books/index.tsx
+++ b/src/routes/books/index.tsx
@@ -1,12 +1,29 @@
 import { Center, Loader, Paper } from "@mantine/core";
 import { createFileRoute } from "@tanstack/react-router";
 import React from "react";
+import { z } from "zod";
 import { BookAddButton } from "../../features/books/BookAddButton";
 import { BookList } from "../../features/books/BookList";
 import { Book, graphQlBookToBook } from "../../features/books/entity/Book";
 import { useBooks } from "../../compoments/hooks/useBooks";
 
+const columnFilterSchema = z.object({
+  id: z.string(),
+  value: z.unknown(),
+});
+
+const sortingItemSchema = z.object({
+  id: z.string(),
+  desc: z.boolean(),
+});
+
 export const Route = createFileRoute("/books/")({
+  validateSearch: z.object({
+    columnFilters: z.array(columnFilterSchema).optional(),
+    sorting: z.array(sortingItemSchema).optional(),
+    pageIndex: z.number().optional(),
+    pageSize: z.number().optional(),
+  }),
   component: RouteComponent,
 });
 

--- a/src/routes/books/index.tsx
+++ b/src/routes/books/index.tsx
@@ -21,8 +21,8 @@ export const Route = createFileRoute("/books/")({
   validateSearch: z.object({
     columnFilters: z.array(columnFilterSchema).optional(),
     sorting: z.array(sortingItemSchema).optional(),
-    pageIndex: z.number().optional(),
-    pageSize: z.number().optional(),
+    pageIndex: z.number().nonnegative().optional(),
+    pageSize: z.number().nonnegative().optional(),
   }),
   component: RouteComponent,
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 作成直後の詳細ページ遷移先の検証を修正しました（新規作成後に正しい詳細ページへ遷移することを確認）

* **新機能**
  * 読了／所有／形式／著者などの複合フィルタ、並び替え、プリセット、リセットの動作を改善し表示制御を強化
  * フィルタ・ソート状態がURLで保持され、リロードや履歴復元で維持されるように

* **テスト**
  * フィルタ・ソート・URL永続化とリセットを検証する包括的なE2Eおよびコンポーネントテストを追加

* **ドキュメント**
  * Mantineコンポーネント向けのテストガイドを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->