### PR TITLE
Add ISBN lookup feature with Google Books API integration

### DIFF
--- a/.agent/plans/20260416-fix-ndl-cors.md
+++ b/.agent/plans/20260416-fix-ndl-cors.md
@@ -1,0 +1,232 @@
+# Fix NDL API CORS error in ISBN auto-fill
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Refer to `.agent/PLANS.md` for the full authoring and maintenance rules that govern this document.
+
+
+## Purpose / Big Picture
+
+The ISBN auto-fill button on the book registration form (the "自動入力" button) fetches book metadata from the National Diet Library (NDL) OpenSearch API at `https://ndlsearch.ndl.go.jp/api/opensearch`. Browsers enforce the Same-Origin Policy: they will block any cross-origin request whose response does not carry permissive CORS headers. NDL does not send those headers, so the browser refuses the response before the JavaScript code ever sees it. The result is that clicking "自動入力" always fails with a CORS error, and the title/author fields are never populated.
+
+After this change, the browser no longer makes a cross-origin request to NDL at all. Instead, it requests a same-origin path (`/ndl-proxy/...`) which is transparently forwarded to NDL by the server:
+
+- In development (`npm start`, which runs `vite`): the Vite development server proxies the request.
+- In E2E tests (`npm run test:e2e`, which builds and runs `vite preview`): the Vite preview server proxies the request.
+- In production (Vercel): a rewrite rule in `vercel.json` proxies the request.
+
+A human can verify the fix by opening the book registration form, typing a real ISBN such as `9784065362433`, clicking "自動入力", and observing that the title and author fields are populated without a CORS error in the browser console.
+
+
+## Progress
+
+- [x] Milestone 1 — Proxy configuration and hook URL change
+- [x] Milestone 2 — Update unit tests
+- [x] Milestone 3 — Update README.md
+
+
+## Surprises & Discoveries
+
+(None yet.)
+
+
+## Decision Log
+
+- Decision: Use `/ndl-proxy` as the path prefix for the proxy.
+  Rationale: Short, clearly names the intent, unlikely to conflict with any existing route in the SPA.
+  Date/Author: 2026-04-16
+
+- Decision: Add both `server.proxy` and `preview.proxy` in `vite.config.ts`.
+  Rationale: The Playwright E2E suite runs `npm run build && npm run preview` (see `playwright.config.ts` `webServer.command`). The `preview` server does not inherit `server.proxy`, so it needs its own entry.
+  Date/Author: 2026-04-16
+
+- Decision: Add a proxy entry to `vercel.json` rather than routing through `bookshelf-api`.
+  Rationale: The frontend is a static SPA already deployed on Vercel; adding a rewrite in `vercel.json` requires no changes to the separate backend repository.
+  Date/Author: 2026-04-16
+
+- Decision: Add a "NDL Proxy" section to `README.md`.
+  Rationale: The proxy configuration is non-obvious. A future contributor who sees `/ndl-proxy` paths in the code needs to understand why they exist and what sets them up.
+  Date/Author: 2026-04-16
+
+
+## Outcomes & Retrospective
+
+Completed 2026-04-16. All three milestones landed in a single commit (`1850a15`). The only surprise was a Biome formatter failure: the plan used single quotes and a multi-line `fetch(...)` call, but the project enforces double quotes and Biome collapsed the short call to one line. Fixed before committing.
+
+
+## Context and Orientation
+
+This repository is a React + TypeScript single-page application (SPA) built with Vite. It has no server of its own; it communicates with a separate GraphQL backend (`bookshelf-api`). It is deployed to Vercel as a static site.
+
+Key files relevant to this plan:
+
+- `src/features/books/useIsbnLookup.ts` — React hook that fetches book metadata from NDL (primary) and Google Books (fallback). This is where the browser-side `fetch` calls live.
+- `src/features/books/useIsbnLookup.test.ts` — Vitest unit tests for the hook. Tests stub `globalThis.fetch` with `vi.stubGlobal`, so they are unaffected by real network restrictions, but the asserted URL must match what the hook actually calls.
+- `vite.config.ts` — Vite configuration file at the repository root. Controls the dev server (`server.*`) and the preview server (`preview.*`). Both support a `proxy` option that rewrites outbound requests before they leave the server.
+- `vercel.json` — Vercel deployment configuration at the repository root. Currently contains one rewrite rule that redirects all paths to `index.html` (the standard SPA catch-all). Vercel processes rewrite rules in array order, so more-specific rules must appear before the catch-all.
+- `playwright.config.ts` — Playwright configuration. The `webServer.command` is `npm run build && npm run preview`, confirming that E2E tests run against the preview server on port 4173.
+- `README.md` — Project documentation. The "How to run locally" section describes the development workflow.
+
+"Proxy" in this context means: the Vite (or Vercel) server intercepts a request from the browser to `/ndl-proxy/...`, strips the `/ndl-proxy` prefix, and forwards the request to `https://ndlsearch.ndl.go.jp/...`. From the browser's perspective the request is same-origin, so no CORS policy applies.
+
+
+## Plan of Work
+
+### Milestone 1 — Proxy configuration and hook URL change
+
+Edit `vite.config.ts` to add a proxy entry under both `server` and `preview`. The existing `server` block only sets `port: 3000`; add a `proxy` key alongside it. The existing `preview` block only sets `port: 4173`; add a `proxy` key alongside it. Both proxy blocks are identical:
+
+    '/ndl-proxy': {
+      target: 'https://ndlsearch.ndl.go.jp',
+      changeOrigin: true,
+      rewrite: (path) => path.replace(/^\/ndl-proxy/, ''),
+    }
+
+The `changeOrigin: true` option makes Vite set the `Host` header to `ndlsearch.ndl.go.jp` in the forwarded request, which is required for the NDL server to respond correctly.
+
+Edit `vercel.json` to prepend a new rewrite rule before the existing catch-all. The file currently contains:
+
+    {
+      "rewrites": [{ "source": "/:path*", "destination": "/index.html" }]
+    }
+
+Change it to:
+
+    {
+      "rewrites": [
+        {
+          "source": "/ndl-proxy/:path*",
+          "destination": "https://ndlsearch.ndl.go.jp/:path*"
+        },
+        { "source": "/:path*", "destination": "/index.html" }
+      ]
+    }
+
+The new rule must come first. If it were placed after the catch-all, Vercel would match every `/ndl-proxy/...` request against the catch-all and serve `index.html` instead of proxying.
+
+Edit `src/features/books/useIsbnLookup.ts`. In the `tryNdl` function (around line 29), change the fetch URL from the absolute NDL URL to the relative proxy path:
+
+    // Before
+    `https://ndlsearch.ndl.go.jp/api/opensearch?isbn=${isbn}`
+
+    // After
+    `/ndl-proxy/api/opensearch?isbn=${isbn}`
+
+No other changes are needed in this file. The Google Books URL in `tryGoogleBooks` remains absolute because Google Books supports CORS and the browser can call it directly.
+
+### Milestone 2 — Update unit tests
+
+Edit `src/features/books/useIsbnLookup.test.ts`. The test named "calls NDL URL with normalized ISBN" (around line 55) asserts the exact URL passed to `fetch`. Update the expected value to match the new relative path:
+
+    // Before
+    "https://ndlsearch.ndl.go.jp/api/opensearch?isbn=9784065362433"
+
+    // After
+    "/ndl-proxy/api/opensearch?isbn=9784065362433"
+
+No other test assertions reference the NDL URL. The Google Books URL assertion (in the test "falls back to Google Books when NDL returns no items") remains unchanged.
+
+### Milestone 3 — Update README.md
+
+Add a new top-level section "NDL Proxy" to `README.md` after the existing "E2E Testing" section. The section should explain:
+
+- Why the proxy exists (NDL does not send CORS headers; without a proxy the browser blocks the request).
+- Where each environment sets up the proxy: Vite dev server and preview server (`vite.config.ts`), Vercel production deployment (`vercel.json`).
+- That the hook calls `/ndl-proxy/api/opensearch?isbn=...`, which each environment forwards to `https://ndlsearch.ndl.go.jp/api/opensearch?isbn=...`.
+
+
+## Concrete Steps
+
+All commands are run from the repository root (`/home/hiterm/ghq/github.com/hiterm/bookshelf`).
+
+Step 1 — Edit `vite.config.ts`. The resulting `server` and `preview` blocks should look like this:
+
+    server: {
+      port: 3000,
+      proxy: {
+        '/ndl-proxy': {
+          target: 'https://ndlsearch.ndl.go.jp',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/ndl-proxy/, ''),
+        },
+      },
+    },
+    preview: {
+      port: 4173,
+      proxy: {
+        '/ndl-proxy': {
+          target: 'https://ndlsearch.ndl.go.jp',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/ndl-proxy/, ''),
+        },
+      },
+    },
+
+Step 2 — Edit `vercel.json` to the content shown in the Plan of Work section above.
+
+Step 3 — Edit `src/features/books/useIsbnLookup.ts` line 30: change the fetch URL to `/ndl-proxy/api/opensearch?isbn=${isbn}`.
+
+Step 4 — Edit `src/features/books/useIsbnLookup.test.ts`: update the expected URL string in the "calls NDL URL with normalized ISBN" test.
+
+Step 5 — Edit `README.md`: add the NDL Proxy section.
+
+Step 6 — Run the pre-commit checklist:
+
+    npm run generate
+    npm run test
+    npm run typecheck
+    npm run lint
+
+All four commands must exit with code 0 before committing.
+
+Step 7 — Commit. Follow the 50/72 rule and present-tense English. A suitable title: `Proxy NDL API requests to fix CORS error`. No body is required.
+
+
+## Validation and Acceptance
+
+Unit tests: run `npm run test`. The suite must pass. The test "calls NDL URL with normalized ISBN" must assert the new relative URL `/ndl-proxy/api/opensearch?isbn=9784065362433` and pass.
+
+Manual verification in dev: run `npm start`, navigate to the book registration page, type ISBN `9784065362433` in the ISBN field, and click "自動入力". The title field should populate with the book title and the author field should populate with the author. The browser console must show no CORS errors.
+
+E2E tests are not expected to cover the ISBN auto-fill interaction (the existing E2E tests only fill in the ISBN text field manually and do not click the auto-fill button). If E2E tests are run (`npm run test:e2e`), they should continue to pass without regression.
+
+
+## Idempotence and Recovery
+
+All edits are additive changes to existing files. If something goes wrong mid-way, `git diff` will show the partial state and `git restore <file>` can reset any individual file to the last committed state. Running `npm run test` after each file edit confirms no regression was introduced.
+
+
+## Artifacts and Notes
+
+The current content of `vercel.json` before this change:
+
+    {
+      "rewrites": [{ "source": "/:path*", "destination": "/index.html" }]
+    }
+
+The relevant portion of `playwright.config.ts` (confirms E2E uses preview server):
+
+    webServer: {
+      command: "npm run build && npm run preview",
+      url: "http://localhost:4173",
+      ...
+    }
+
+The current NDL fetch call in `useIsbnLookup.ts` (line 29–31):
+
+    const response = await fetch(
+      `https://ndlsearch.ndl.go.jp/api/opensearch?isbn=${isbn}`,
+    );
+
+The current URL assertion in the unit test (line 67–69):
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://ndlsearch.ndl.go.jp/api/opensearch?isbn=9784065362433",
+    );
+
+
+## Interfaces and Dependencies
+
+No new npm packages are required. Vite's built-in proxy support (`server.proxy` and `preview.proxy`) uses the `http-proxy` library, which is already included as a Vite dependency. The proxy option type is `Record<string, string | ProxyOptions>` as exported from `vite`. The `rewrite` field within `ProxyOptions` is `(path: string) => string`.
+
+Vercel's `rewrites` feature supports forwarding to external URLs by setting `destination` to a full `https://` URL; this is a documented Vercel platform capability and requires no additional configuration.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run generate)",
+      "Bash(npm run test)",
+      "Bash(npm run typecheck)",
+      "Bash(npm run lint)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git --no-pager status)",
+      "Bash(git --no-pager diff*)",
+      "Bash(git --no-pager log*)"
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -83,3 +83,13 @@ Run demo E2E tests:
 ```bash
 npm run test:e2e:demo
 ```
+
+## NDL Proxy
+
+The book registration form's ISBN auto-fill fetches metadata from the National Diet Library (NDL) OpenSearch API. NDL does not send CORS headers, so browsers block direct cross-origin requests to `https://ndlsearch.ndl.go.jp`.
+
+To work around this, the hook calls the relative path `/ndl-proxy/api/opensearch?isbn=...`, which each environment forwards to `https://ndlsearch.ndl.go.jp/api/opensearch?isbn=...`:
+
+- **Development** (`npm start`): Vite dev server proxy configured in `vite.config.ts` under `server.proxy`.
+- **E2E tests** (`npm run test:e2e`): Vite preview server proxy configured in `vite.config.ts` under `preview.proxy`.
+- **Production** (Vercel): Rewrite rule in `vercel.json` forwards `/ndl-proxy/:path*` to `https://ndlsearch.ndl.go.jp/:path*`.

--- a/src/features/books/BookAddButton.tsx
+++ b/src/features/books/BookAddButton.tsx
@@ -70,6 +70,7 @@ export const BookAddButton: React.FC = () => {
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     onSubmit: submitBook,
     initialValues: emptyBook,
+    enableIsbnLookup: true,
   });
 
   return (

--- a/src/features/books/BookForm.tsx
+++ b/src/features/books/BookForm.tsx
@@ -58,6 +58,10 @@ type BookFormReturn = {
   submitForm: React.EventHandler<React.SyntheticEvent<HTMLFormElement>>;
 };
 
+const normalizeIsbn = (isbn: string): string => isbn.replace(/-/g, "");
+const isValidIsbn13 = (isbn: string): boolean =>
+  /^\d{13}$/.test(normalizeIsbn(isbn));
+
 export const useBookForm = (props: BookFormProps): BookFormReturn => {
   const form = useForm({
     initialValues: props.initialValues,
@@ -108,10 +112,10 @@ export const useBookForm = (props: BookFormProps): BookFormReturn => {
         />
         <ActionIcon
           onClick={() => {
-            void lookupIsbn(form.values.isbn);
+            void lookupIsbn(normalizeIsbn(form.values.isbn));
           }}
           loading={isbnLookupState.status === "loading"}
-          disabled={!form.values.isbn}
+          disabled={!isValidIsbn13(form.values.isbn)}
           size="lg"
           variant="default"
           aria-label="自動入力"
@@ -120,7 +124,7 @@ export const useBookForm = (props: BookFormProps): BookFormReturn => {
         </ActionIcon>
       </Group>
       {isbnLookupState.status === "error" && (
-        <Text size="xs" c="red" mt={4}>
+        <Text size="xs" c="red" mt={4} role="alert">
           {isbnLookupState.message}
         </Text>
       )}

--- a/src/features/books/BookForm.tsx
+++ b/src/features/books/BookForm.tsx
@@ -21,6 +21,7 @@ import { Author } from "./entity/Author";
 import { BOOK_FORMAT_VALUE, displayBookFormat } from "./entity/BookFormat";
 import { BOOK_STORE_VALUE, displayBookStore } from "./entity/BookStore";
 import { useIsbnLookup } from "./useIsbnLookup";
+import { normalizeIsbn, isValidIsbn13 } from "./isbnUtils";
 
 export type BookFormValues = {
   title: string;
@@ -58,10 +59,6 @@ type BookFormReturn = {
   submitForm: React.EventHandler<React.SyntheticEvent<HTMLFormElement>>;
 };
 
-const normalizeIsbn = (isbn: string): string => isbn.replace(/-/g, "");
-const isValidIsbn13 = (isbn: string): boolean =>
-  /^\d{13}$/.test(normalizeIsbn(isbn));
-
 export const useBookForm = (props: BookFormProps): BookFormReturn => {
   const form = useForm({
     initialValues: props.initialValues,
@@ -81,7 +78,8 @@ export const useBookForm = (props: BookFormProps): BookFormReturn => {
         result.authorNames
           .map((name) =>
             data.authors.find(
-              (a) => a.name.toLowerCase() === name.toLowerCase(),
+              (a) =>
+                a.name.trim().toLowerCase() === name.trim().toLowerCase(),
             ),
           )
           .filter((a): a is Author => a !== undefined)

--- a/src/features/books/BookForm.tsx
+++ b/src/features/books/BookForm.tsx
@@ -76,11 +76,18 @@ export const useBookForm = (props: BookFormProps): BookFormReturn => {
     const result = await lookupIsbn(normalizeIsbn(form.values.isbn));
     if (result == null || data == null) return;
     form.setFieldValue("title", result.title);
-    const matched = result.authorNames
-      .map((name) =>
-        data.authors.find((a) => a.name.toLowerCase() === name.toLowerCase()),
-      )
-      .filter((a): a is Author => a !== undefined);
+    const matched = Array.from(
+      new Map(
+        result.authorNames
+          .map((name) =>
+            data.authors.find(
+              (a) => a.name.toLowerCase() === name.toLowerCase(),
+            ),
+          )
+          .filter((a): a is Author => a !== undefined)
+          .map((a) => [a.id, a]),
+      ).values(),
+    );
     if (matched.length > 0) {
       form.setFieldValue("authors", matched);
     }

--- a/src/features/books/BookForm.tsx
+++ b/src/features/books/BookForm.tsx
@@ -110,7 +110,7 @@ export const useBookForm = (props: BookFormProps): BookFormReturn => {
           disabled={!form.values.isbn}
           size="lg"
           variant="default"
-          aria-label="ISBNから自動入力"
+          aria-label="自動入力"
         >
           <IconSearch size={16} />
         </ActionIcon>

--- a/src/features/books/BookForm.tsx
+++ b/src/features/books/BookForm.tsx
@@ -12,7 +12,7 @@ import {
 } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { zodResolver } from "mantine-form-zod-resolver";
-import React, { ReactElement, useEffect } from "react";
+import React, { ReactElement } from "react";
 import { z } from "zod";
 import { IconSearch } from "@tabler/icons-react";
 import { BookFormat, BookStore } from "../../generated/graphql-request";
@@ -72,25 +72,19 @@ export const useBookForm = (props: BookFormProps): BookFormReturn => {
   const { data, isLoading, error } = useAuthors();
   const { state: isbnLookupState, lookup: lookupIsbn } = useIsbnLookup();
 
-  useEffect(() => {
-    if (isbnLookupState.status !== "success") return;
-    form.setFieldValue("title", isbnLookupState.result.title);
-    if (data != null) {
-      const matched = isbnLookupState.result.authorNames
-        .map((name) =>
-          data.authors.find((a) => a.name.toLowerCase() === name.toLowerCase()),
-        )
-        .filter((a): a is Author => a !== undefined);
-      if (matched.length > 0) {
-        form.setFieldValue("authors", matched);
-      }
+  const handleIsbnLookup = async () => {
+    const result = await lookupIsbn(normalizeIsbn(form.values.isbn));
+    if (result == null || data == null) return;
+    form.setFieldValue("title", result.title);
+    const matched = result.authorNames
+      .map((name) =>
+        data.authors.find((a) => a.name.toLowerCase() === name.toLowerCase()),
+      )
+      .filter((a): a is Author => a !== undefined);
+    if (matched.length > 0) {
+      form.setFieldValue("authors", matched);
     }
-    // form.setFieldValue is a stable callback (Mantine useForm guarantees this).
-    // data is omitted intentionally: it is stable once loaded (React Query
-    // caches it), and including it would re-apply a stale lookup result
-    // whenever the authors list refreshes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isbnLookupState]);
+  };
 
   const submitForm = form.onSubmit(props.onSubmit);
 
@@ -112,7 +106,7 @@ export const useBookForm = (props: BookFormProps): BookFormReturn => {
         />
         <ActionIcon
           onClick={() => {
-            void lookupIsbn(normalizeIsbn(form.values.isbn));
+            void handleIsbnLookup();
           }}
           loading={isbnLookupState.status === "loading"}
           disabled={!isValidIsbn13(form.values.isbn)}

--- a/src/features/books/BookForm.tsx
+++ b/src/features/books/BookForm.tsx
@@ -1,21 +1,26 @@
 import {
+  ActionIcon,
   Checkbox,
+  Group,
   Loader,
   MultiSelect,
   NumberInput,
   Select,
   Stack,
+  Text,
   TextInput,
 } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { zodResolver } from "mantine-form-zod-resolver";
-import React, { ReactElement } from "react";
+import React, { ReactElement, useEffect } from "react";
 import { z } from "zod";
+import { IconSearch } from "@tabler/icons-react";
 import { BookFormat, BookStore } from "../../generated/graphql-request";
 import { useAuthors } from "../../compoments/hooks/useAuthors";
 import { Author } from "./entity/Author";
 import { BOOK_FORMAT_VALUE, displayBookFormat } from "./entity/BookFormat";
 import { BOOK_STORE_VALUE, displayBookStore } from "./entity/BookStore";
+import { useIsbnLookup } from "./useIsbnLookup";
 
 export type BookFormValues = {
   title: string;
@@ -45,6 +50,7 @@ type BookFormProps = {
     event: React.SyntheticEvent<HTMLFormElement> | undefined,
   ) => void;
   initialValues: BookFormValues;
+  enableIsbnLookup?: boolean;
 };
 
 type BookFormReturn = {
@@ -60,6 +66,23 @@ export const useBookForm = (props: BookFormProps): BookFormReturn => {
   });
 
   const { data, isLoading, error } = useAuthors();
+  const { state: isbnLookupState, lookup: lookupIsbn } = useIsbnLookup();
+
+  useEffect(() => {
+    if (isbnLookupState.status !== "success") return;
+    form.setFieldValue("title", isbnLookupState.result.title);
+    if (data != null) {
+      const matched = isbnLookupState.result.authorNames
+        .map((name) =>
+          data.authors.find((a) => a.name.toLowerCase() === name.toLowerCase()),
+        )
+        .filter((a): a is Author => a !== undefined);
+      if (matched.length > 0) {
+        form.setFieldValue("authors", matched);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isbnLookupState]);
 
   const submitForm = form.onSubmit(props.onSubmit);
 
@@ -70,6 +93,37 @@ export const useBookForm = (props: BookFormProps): BookFormReturn => {
   if (isLoading || data == null) {
     return { form: <Loader />, submitForm };
   }
+
+  const isbnField = props.enableIsbnLookup ? (
+    <Stack gap={0}>
+      <Group align="flex-end" gap="xs">
+        <TextInput
+          label="ISBN"
+          style={{ flex: 1 }}
+          {...form.getInputProps("isbn")}
+        />
+        <ActionIcon
+          onClick={() => {
+            void lookupIsbn(form.values.isbn);
+          }}
+          loading={isbnLookupState.status === "loading"}
+          disabled={!form.values.isbn}
+          size="lg"
+          variant="default"
+          aria-label="ISBNから自動入力"
+        >
+          <IconSearch size={16} />
+        </ActionIcon>
+      </Group>
+      {isbnLookupState.status === "error" && (
+        <Text size="xs" c="red" mt={4}>
+          {isbnLookupState.message}
+        </Text>
+      )}
+    </Stack>
+  ) : (
+    <TextInput label="ISBN" {...form.getInputProps("isbn")} />
+  );
 
   const formElement = (
     <Stack>
@@ -110,7 +164,7 @@ export const useBookForm = (props: BookFormProps): BookFormReturn => {
         }))}
       />
       <NumberInput label="優先度" {...form.getInputProps("priority")} />
-      <TextInput label="ISBN" {...form.getInputProps("isbn")} />
+      {isbnField}
       <Checkbox
         label="既読"
         {...form.getInputProps("read", { type: "checkbox" })}

--- a/src/features/books/BookForm.tsx
+++ b/src/features/books/BookForm.tsx
@@ -81,6 +81,10 @@ export const useBookForm = (props: BookFormProps): BookFormReturn => {
         form.setFieldValue("authors", matched);
       }
     }
+    // form.setFieldValue is a stable callback (Mantine useForm guarantees this).
+    // data is omitted intentionally: it is stable once loaded (React Query
+    // caches it), and including it would re-apply a stale lookup result
+    // whenever the authors list refreshes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isbnLookupState]);
 

--- a/src/features/books/BookForm.tsx
+++ b/src/features/books/BookForm.tsx
@@ -78,8 +78,7 @@ export const useBookForm = (props: BookFormProps): BookFormReturn => {
         result.authorNames
           .map((name) =>
             data.authors.find(
-              (a) =>
-                a.name.trim().toLowerCase() === name.trim().toLowerCase(),
+              (a) => a.name.trim().toLowerCase() === name.trim().toLowerCase(),
             ),
           )
           .filter((a): a is Author => a !== undefined)

--- a/src/features/books/BookForm.tsx
+++ b/src/features/books/BookForm.tsx
@@ -21,7 +21,6 @@ import { Author } from "./entity/Author";
 import { BOOK_FORMAT_VALUE, displayBookFormat } from "./entity/BookFormat";
 import { BOOK_STORE_VALUE, displayBookStore } from "./entity/BookStore";
 import { useIsbnLookup } from "./useIsbnLookup";
-import { normalizeIsbn, isValidIsbn13 } from "./isbnUtils";
 
 export type BookFormValues = {
   title: string;
@@ -70,7 +69,7 @@ export const useBookForm = (props: BookFormProps): BookFormReturn => {
   const { state: isbnLookupState, lookup: lookupIsbn } = useIsbnLookup();
 
   const handleIsbnLookup = async () => {
-    const result = await lookupIsbn(normalizeIsbn(form.values.isbn));
+    const result = await lookupIsbn(form.values.isbn);
     if (result == null || data == null) return;
     form.setFieldValue("title", result.title);
     const matched = Array.from(
@@ -113,7 +112,6 @@ export const useBookForm = (props: BookFormProps): BookFormReturn => {
             void handleIsbnLookup();
           }}
           loading={isbnLookupState.status === "loading"}
-          disabled={!isValidIsbn13(form.values.isbn)}
           size="lg"
           variant="default"
           aria-label="自動入力"

--- a/src/features/books/isbnUtils.ts
+++ b/src/features/books/isbnUtils.ts
@@ -1,0 +1,3 @@
+export const normalizeIsbn = (isbn: string): string => isbn.replace(/-/g, "");
+export const isValidIsbn13 = (isbn: string): boolean =>
+  /^\d{13}$/.test(normalizeIsbn(isbn));

--- a/src/features/books/useIsbnLookup.test.ts
+++ b/src/features/books/useIsbnLookup.test.ts
@@ -7,6 +7,16 @@ const makeResponse = (body: unknown) =>
     json: () => Promise.resolve(body),
   } as Response);
 
+const openBdFound = (title: string, author: string) =>
+  makeResponse([{ summary: { title, author } }]);
+
+const openBdNotFound = () => makeResponse([null]);
+
+const googleBooksFound = (title: string, authors: string[]) =>
+  makeResponse({ items: [{ volumeInfo: { title, authors } }] });
+
+const googleBooksNotFound = () => makeResponse({});
+
 beforeEach(() => {
   vi.stubGlobal("fetch", vi.fn());
 });
@@ -21,54 +31,73 @@ describe("useIsbnLookup", () => {
     expect(result.current.state.status).toBe("idle");
   });
 
-  test("calls correct URL and returns title and authorNames on success", async () => {
-    const mockFetch = vi.fn().mockReturnValue(
-      makeResponse({
-        items: [
-          {
-            volumeInfo: {
-              title: "Test Book",
-              authors: ["Author One", "Author Two"],
-            },
-          },
-        ],
-      }),
-    );
+  test("calls OpenBD URL with normalized ISBN", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockReturnValue(openBdFound("Test Book", "Author One"));
     vi.stubGlobal("fetch", mockFetch);
 
     const { result } = renderHook(() => useIsbnLookup());
 
     await act(async () => {
-      await result.current.lookup("978-4-00-000000-1");
+      await result.current.lookup("978-4-06-536243-3");
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      "https://www.googleapis.com/books/v1/volumes?q=isbn:9784000000001",
+      "https://api.openbd.jp/v1/get?isbn=9784065362433",
     );
-    expect(result.current.state.status).toBe("success");
-    if (result.current.state.status === "success") {
-      expect(result.current.state.result.title).toBe("Test Book");
-      expect(result.current.state.result.authorNames).toEqual([
-        "Author One",
-        "Author Two",
-      ]);
-    }
   });
 
-  test("returns empty authorNames when authors field is absent", async () => {
+  test("returns title and authorNames from OpenBD on success", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockReturnValue(
-        makeResponse({
-          items: [{ volumeInfo: { title: "No Authors Book" } }],
-        }),
-      ),
+      vi.fn().mockReturnValue(openBdFound("テスト書籍", "著者一／著者二")),
     );
 
     const { result } = renderHook(() => useIsbnLookup());
 
     await act(async () => {
-      await result.current.lookup("9784000000001");
+      await result.current.lookup("9784065362433");
+    });
+
+    expect(result.current.state.status).toBe("success");
+    if (result.current.state.status === "success") {
+      expect(result.current.state.result.title).toBe("テスト書籍");
+      expect(result.current.state.result.authorNames).toEqual([
+        "著者一",
+        "著者二",
+      ]);
+    }
+  });
+
+  test("parses single author without separator", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockReturnValue(openBdFound("テスト書籍", "著者一")),
+    );
+
+    const { result } = renderHook(() => useIsbnLookup());
+
+    await act(async () => {
+      await result.current.lookup("9784065362433");
+    });
+
+    expect(result.current.state.status).toBe("success");
+    if (result.current.state.status === "success") {
+      expect(result.current.state.result.authorNames).toEqual(["著者一"]);
+    }
+  });
+
+  test("returns empty authorNames when author field is empty", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockReturnValue(openBdFound("タイトル", "")),
+    );
+
+    const { result } = renderHook(() => useIsbnLookup());
+
+    await act(async () => {
+      await result.current.lookup("9784065362433");
     });
 
     expect(result.current.state.status).toBe("success");
@@ -77,25 +106,39 @@ describe("useIsbnLookup", () => {
     }
   });
 
-  test("transitions to error when items array is empty", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockReturnValue(makeResponse({ items: [] })),
-    );
+  test("falls back to Google Books when OpenBD returns null", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockReturnValueOnce(openBdNotFound())
+      .mockReturnValueOnce(googleBooksFound("English Book", ["John Doe"]));
+    vi.stubGlobal("fetch", mockFetch);
 
     const { result } = renderHook(() => useIsbnLookup());
 
     await act(async () => {
-      await result.current.lookup("9784000000001");
+      await result.current.lookup("9780000000001");
     });
 
-    await waitFor(() => {
-      expect(result.current.state.status).toBe("error");
-    });
+    expect(result.current.state.status).toBe("success");
+    if (result.current.state.status === "success") {
+      expect(result.current.state.result.title).toBe("English Book");
+      expect(result.current.state.result.authorNames).toEqual(["John Doe"]);
+    }
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      "https://www.googleapis.com/books/v1/volumes?q=isbn:9780000000001",
+    );
   });
 
-  test("transitions to error when items key is absent", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockReturnValue(makeResponse({})));
+  test("transitions to error when both APIs return not found", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockReturnValueOnce(openBdNotFound())
+        .mockReturnValueOnce(googleBooksNotFound()),
+    );
 
     const { result } = renderHook(() => useIsbnLookup());
 
@@ -117,7 +160,7 @@ describe("useIsbnLookup", () => {
     const { result } = renderHook(() => useIsbnLookup());
 
     await act(async () => {
-      await result.current.lookup("9784000000001");
+      await result.current.lookup("9784065362433");
     });
 
     await waitFor(() => {

--- a/src/features/books/useIsbnLookup.test.ts
+++ b/src/features/books/useIsbnLookup.test.ts
@@ -1,0 +1,127 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+import { useIsbnLookup } from "./useIsbnLookup";
+
+const makeResponse = (body: unknown) =>
+  Promise.resolve({
+    json: () => Promise.resolve(body),
+  } as Response);
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useIsbnLookup", () => {
+  test("initial state is idle", () => {
+    const { result } = renderHook(() => useIsbnLookup());
+    expect(result.current.state.status).toBe("idle");
+  });
+
+  test("calls correct URL and returns title and authorNames on success", async () => {
+    const mockFetch = vi.fn().mockReturnValue(
+      makeResponse({
+        items: [
+          {
+            volumeInfo: {
+              title: "Test Book",
+              authors: ["Author One", "Author Two"],
+            },
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { result } = renderHook(() => useIsbnLookup());
+
+    await act(async () => {
+      await result.current.lookup("978-4-00-000000-1");
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://www.googleapis.com/books/v1/volumes?q=isbn:9784000000001",
+    );
+    expect(result.current.state.status).toBe("success");
+    if (result.current.state.status === "success") {
+      expect(result.current.state.result.title).toBe("Test Book");
+      expect(result.current.state.result.authorNames).toEqual([
+        "Author One",
+        "Author Two",
+      ]);
+    }
+  });
+
+  test("returns empty authorNames when authors field is absent", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockReturnValue(
+        makeResponse({
+          items: [{ volumeInfo: { title: "No Authors Book" } }],
+        }),
+      ),
+    );
+
+    const { result } = renderHook(() => useIsbnLookup());
+
+    await act(async () => {
+      await result.current.lookup("9784000000001");
+    });
+
+    expect(result.current.state.status).toBe("success");
+    if (result.current.state.status === "success") {
+      expect(result.current.state.result.authorNames).toEqual([]);
+    }
+  });
+
+  test("transitions to error when items array is empty", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockReturnValue(makeResponse({ items: [] })),
+    );
+
+    const { result } = renderHook(() => useIsbnLookup());
+
+    await act(async () => {
+      await result.current.lookup("9784000000001");
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("error");
+    });
+  });
+
+  test("transitions to error when items key is absent", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(makeResponse({})));
+
+    const { result } = renderHook(() => useIsbnLookup());
+
+    await act(async () => {
+      await result.current.lookup("9784000000001");
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("error");
+    });
+  });
+
+  test("transitions to error on network failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockReturnValue(Promise.reject(new Error("network error"))),
+    );
+
+    const { result } = renderHook(() => useIsbnLookup());
+
+    await act(async () => {
+      await result.current.lookup("9784000000001");
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("error");
+    });
+  });
+});

--- a/src/features/books/useIsbnLookup.test.ts
+++ b/src/features/books/useIsbnLookup.test.ts
@@ -153,6 +153,9 @@ describe("useIsbnLookup", () => {
     await waitFor(() => {
       expect(result.current.state.status).toBe("error");
     });
+    if (result.current.state.status === "error") {
+      expect(result.current.state.message).toBe("取得に失敗しました");
+    }
   });
 
   test("transitions to loading immediately when lookup starts", () => {

--- a/src/features/books/useIsbnLookup.test.ts
+++ b/src/features/books/useIsbnLookup.test.ts
@@ -4,13 +4,15 @@ import { useIsbnLookup } from "./useIsbnLookup";
 
 const DC_NS = "http://purl.org/dc/elements/1.1/";
 
-const makeTextResponse = (text: string) =>
+const makeTextResponse = (text: string, ok = true) =>
   Promise.resolve({
+    ok,
     text: () => Promise.resolve(text),
   } as Response);
 
-const makeJsonResponse = (body: unknown) =>
+const makeJsonResponse = (body: unknown, ok = true) =>
   Promise.resolve({
+    ok,
     json: () => Promise.resolve(body),
   } as Response);
 
@@ -136,6 +138,23 @@ describe("useIsbnLookup", () => {
     );
   });
 
+  test("transitions to error on HTTP error response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockReturnValue(makeTextResponse("", false)),
+    );
+
+    const { result } = renderHook(() => useIsbnLookup());
+
+    await act(async () => {
+      await result.current.lookup("9784065362433");
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("error");
+    });
+  });
+
   test("transitions to error when both APIs return not found", async () => {
     vi.stubGlobal(
       "fetch",
@@ -171,5 +190,38 @@ describe("useIsbnLookup", () => {
     await waitFor(() => {
       expect(result.current.state.status).toBe("error");
     });
+  });
+
+  test("discards stale response when a newer lookup is in flight", async () => {
+    let resolveFirst!: (value: Response) => void;
+    const firstResponse = new Promise<Response>(
+      (resolve) => (resolveFirst = resolve),
+    );
+
+    const mockFetch = vi
+      .fn()
+      .mockReturnValueOnce(firstResponse)
+      .mockReturnValueOnce(makeTextResponse(ndlXml("新しい書籍", ["著者B"])));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { result } = renderHook(() => useIsbnLookup());
+
+    act(() => {
+      void result.current.lookup("9784000000001");
+    });
+
+    await act(async () => {
+      await result.current.lookup("9784000000002");
+    });
+
+    resolveFirst(await makeTextResponse(ndlXml("古い書籍", ["著者A"])));
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("success");
+    });
+
+    if (result.current.state.status === "success") {
+      expect(result.current.state.result.title).toBe("新しい書籍");
+    }
   });
 });

--- a/src/features/books/useIsbnLookup.test.ts
+++ b/src/features/books/useIsbnLookup.test.ts
@@ -2,20 +2,39 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
 import { useIsbnLookup } from "./useIsbnLookup";
 
-const makeResponse = (body: unknown) =>
+const DC_NS = "http://purl.org/dc/elements/1.1/";
+
+const makeTextResponse = (text: string) =>
+  Promise.resolve({
+    text: () => Promise.resolve(text),
+  } as Response);
+
+const makeJsonResponse = (body: unknown) =>
   Promise.resolve({
     json: () => Promise.resolve(body),
   } as Response);
 
-const openBdFound = (title: string, author: string) =>
-  makeResponse([{ summary: { title, author } }]);
+const ndlXml = (title: string, creators: string[]) =>
+  `<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:dc="${DC_NS}">
+  <channel>
+    <item>
+      <title>${title}</title>
+      ${creators.map((c) => `<dc:creator>${c}</dc:creator>`).join("")}
+    </item>
+  </channel>
+</rss>`;
 
-const openBdNotFound = () => makeResponse([null]);
+const ndlEmptyXml = () =>
+  `<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:dc="${DC_NS}">
+  <channel></channel>
+</rss>`;
 
 const googleBooksFound = (title: string, authors: string[]) =>
-  makeResponse({ items: [{ volumeInfo: { title, authors } }] });
+  makeJsonResponse({ items: [{ volumeInfo: { title, authors } }] });
 
-const googleBooksNotFound = () => makeResponse({});
+const googleBooksNotFound = () => makeJsonResponse({});
 
 beforeEach(() => {
   vi.stubGlobal("fetch", vi.fn());
@@ -31,10 +50,10 @@ describe("useIsbnLookup", () => {
     expect(result.current.state.status).toBe("idle");
   });
 
-  test("calls OpenBD URL with normalized ISBN", async () => {
+  test("calls NDL URL with normalized ISBN", async () => {
     const mockFetch = vi
       .fn()
-      .mockReturnValue(openBdFound("Test Book", "Author One"));
+      .mockReturnValue(makeTextResponse(ndlXml("テスト書籍", ["著者一"])));
     vi.stubGlobal("fetch", mockFetch);
 
     const { result } = renderHook(() => useIsbnLookup());
@@ -44,14 +63,18 @@ describe("useIsbnLookup", () => {
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      "https://api.openbd.jp/v1/get?isbn=9784065362433",
+      "https://ndlsearch.ndl.go.jp/api/opensearch?isbn=9784065362433",
     );
   });
 
-  test("returns title and authorNames from OpenBD on success", async () => {
+  test("returns title and authorNames from NDL on success", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockReturnValue(openBdFound("テスト書籍", "著者一／著者二")),
+      vi
+        .fn()
+        .mockReturnValue(
+          makeTextResponse(ndlXml("テスト書籍", ["著者一", "著者二"])),
+        ),
     );
 
     const { result } = renderHook(() => useIsbnLookup());
@@ -70,28 +93,10 @@ describe("useIsbnLookup", () => {
     }
   });
 
-  test("parses single author without separator", async () => {
+  test("returns empty authorNames when no dc:creator elements", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockReturnValue(openBdFound("テスト書籍", "著者一")),
-    );
-
-    const { result } = renderHook(() => useIsbnLookup());
-
-    await act(async () => {
-      await result.current.lookup("9784065362433");
-    });
-
-    expect(result.current.state.status).toBe("success");
-    if (result.current.state.status === "success") {
-      expect(result.current.state.result.authorNames).toEqual(["著者一"]);
-    }
-  });
-
-  test("returns empty authorNames when author field is empty", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockReturnValue(openBdFound("タイトル", "")),
+      vi.fn().mockReturnValue(makeTextResponse(ndlXml("タイトルのみ", []))),
     );
 
     const { result } = renderHook(() => useIsbnLookup());
@@ -106,10 +111,10 @@ describe("useIsbnLookup", () => {
     }
   });
 
-  test("falls back to Google Books when OpenBD returns null", async () => {
+  test("falls back to Google Books when NDL returns no items", async () => {
     const mockFetch = vi
       .fn()
-      .mockReturnValueOnce(openBdNotFound())
+      .mockReturnValueOnce(makeTextResponse(ndlEmptyXml()))
       .mockReturnValueOnce(googleBooksFound("English Book", ["John Doe"]));
     vi.stubGlobal("fetch", mockFetch);
 
@@ -136,7 +141,7 @@ describe("useIsbnLookup", () => {
       "fetch",
       vi
         .fn()
-        .mockReturnValueOnce(openBdNotFound())
+        .mockReturnValueOnce(makeTextResponse(ndlEmptyXml()))
         .mockReturnValueOnce(googleBooksNotFound()),
     );
 

--- a/src/features/books/useIsbnLookup.test.ts
+++ b/src/features/books/useIsbnLookup.test.ts
@@ -155,6 +155,21 @@ describe("useIsbnLookup", () => {
     });
   });
 
+  test("transitions to loading immediately when lookup starts", () => {
+    // The Promise intentionally never resolves so the hook stays in loading state.
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const pending = new Promise<Response>(() => {});
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(pending));
+
+    const { result } = renderHook(() => useIsbnLookup());
+
+    act(() => {
+      void result.current.lookup("9784065362433");
+    });
+
+    expect(result.current.state.status).toBe("loading");
+  });
+
   test("transitions to error when both APIs return not found", async () => {
     vi.stubGlobal(
       "fetch",
@@ -173,6 +188,9 @@ describe("useIsbnLookup", () => {
     await waitFor(() => {
       expect(result.current.state.status).toBe("error");
     });
+    if (result.current.state.status === "error") {
+      expect(result.current.state.message).toBe("書籍が見つかりませんでした");
+    }
   });
 
   test("transitions to error on network failure", async () => {
@@ -190,6 +208,9 @@ describe("useIsbnLookup", () => {
     await waitFor(() => {
       expect(result.current.state.status).toBe("error");
     });
+    if (result.current.state.status === "error") {
+      expect(result.current.state.message).toBe("取得に失敗しました");
+    }
   });
 
   test("discards stale response when a newer lookup is in flight", async () => {

--- a/src/features/books/useIsbnLookup.test.ts
+++ b/src/features/books/useIsbnLookup.test.ts
@@ -65,7 +65,7 @@ describe("useIsbnLookup", () => {
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      "https://ndlsearch.ndl.go.jp/api/opensearch?isbn=9784065362433",
+      "/ndl-proxy/api/opensearch?isbn=9784065362433",
     );
   });
 

--- a/src/features/books/useIsbnLookup.ts
+++ b/src/features/books/useIsbnLookup.ts
@@ -1,0 +1,57 @@
+import { useState } from "react";
+
+type IsbnLookupResult = {
+  title: string;
+  authorNames: string[];
+};
+
+type IsbnLookupState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; result: IsbnLookupResult }
+  | { status: "error"; message: string };
+
+type GoogleBooksResponse = {
+  items?: {
+    volumeInfo: {
+      title: string;
+      authors?: string[];
+    };
+  }[];
+};
+
+type UseIsbnLookupReturn = {
+  state: IsbnLookupState;
+  lookup: (isbn: string) => Promise<void>;
+};
+
+export const useIsbnLookup = (): UseIsbnLookupReturn => {
+  const [state, setState] = useState<IsbnLookupState>({ status: "idle" });
+
+  const lookup = async (isbn: string): Promise<void> => {
+    const normalized = isbn.replace(/-/g, "");
+    setState({ status: "loading" });
+    try {
+      const response = await fetch(
+        `https://www.googleapis.com/books/v1/volumes?q=isbn:${normalized}`,
+      );
+      const data = (await response.json()) as GoogleBooksResponse;
+      if (!data.items || data.items.length === 0) {
+        setState({ status: "error", message: "書籍が見つかりませんでした" });
+        return;
+      }
+      const volumeInfo = data.items[0].volumeInfo;
+      setState({
+        status: "success",
+        result: {
+          title: volumeInfo.title,
+          authorNames: volumeInfo.authors ?? [],
+        },
+      });
+    } catch {
+      setState({ status: "error", message: "取得に失敗しました" });
+    }
+  };
+
+  return { state, lookup };
+};

--- a/src/features/books/useIsbnLookup.ts
+++ b/src/features/books/useIsbnLookup.ts
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react";
+import { normalizeIsbn } from "./isbnUtils";
 
 type IsbnLookupResult = {
   title: string;
@@ -43,8 +44,8 @@ const tryNdl = async (isbn: string): Promise<IsbnLookupResult | null> => {
     "creator",
   );
   const authorNames = Array.from(creatorElements)
-    .map((el) => el.textContent)
-    .filter(Boolean);
+    .map((el) => el.textContent?.trim())
+    .filter((name): name is string => Boolean(name));
   return { title, authorNames };
 };
 
@@ -71,7 +72,7 @@ export const useIsbnLookup = (): UseIsbnLookupReturn => {
   const latestRequestIdRef = useRef(0);
 
   const lookup = async (isbn: string): Promise<IsbnLookupResult | null> => {
-    const normalized = isbn.replace(/-/g, "");
+    const normalized = normalizeIsbn(isbn);
     latestRequestIdRef.current += 1;
     const requestId = latestRequestIdRef.current;
     setState({ status: "loading" });

--- a/src/features/books/useIsbnLookup.ts
+++ b/src/features/books/useIsbnLookup.ts
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react";
-import { normalizeIsbn } from "./isbnUtils";
+import { normalizeIsbn, isValidIsbn13 } from "./isbnUtils";
 
 type IsbnLookupResult = {
   title: string;
@@ -72,6 +72,10 @@ export const useIsbnLookup = (): UseIsbnLookupReturn => {
   const latestRequestIdRef = useRef(0);
 
   const lookup = async (isbn: string): Promise<IsbnLookupResult | null> => {
+    if (!isValidIsbn13(isbn)) {
+      setState({ status: "error", message: "ISBNが不正です" });
+      return null;
+    }
     const normalized = normalizeIsbn(isbn);
     latestRequestIdRef.current += 1;
     const requestId = latestRequestIdRef.current;

--- a/src/features/books/useIsbnLookup.ts
+++ b/src/features/books/useIsbnLookup.ts
@@ -44,8 +44,8 @@ const tryNdl = async (isbn: string): Promise<IsbnLookupResult | null> => {
     "creator",
   );
   const authorNames = Array.from(creatorElements)
-    .map((el) => el.textContent?.trim())
-    .filter((name): name is string => Boolean(name));
+    .map((el) => el.textContent.trim())
+    .filter(Boolean);
   return { title, authorNames };
 };
 

--- a/src/features/books/useIsbnLookup.ts
+++ b/src/features/books/useIsbnLookup.ts
@@ -22,7 +22,7 @@ type GoogleBooksResponse = {
 
 type UseIsbnLookupReturn = {
   state: IsbnLookupState;
-  lookup: (isbn: string) => Promise<void>;
+  lookup: (isbn: string) => Promise<IsbnLookupResult | null>;
 };
 
 const tryNdl = async (isbn: string): Promise<IsbnLookupResult | null> => {
@@ -72,7 +72,7 @@ export const useIsbnLookup = (): UseIsbnLookupReturn => {
   const [state, setState] = useState<IsbnLookupState>({ status: "idle" });
   const latestRequestIdRef = useRef(0);
 
-  const lookup = async (isbn: string): Promise<void> => {
+  const lookup = async (isbn: string): Promise<IsbnLookupResult | null> => {
     const normalized = isbn.replace(/-/g, "");
     latestRequestIdRef.current += 1;
     const requestId = latestRequestIdRef.current;
@@ -80,15 +80,17 @@ export const useIsbnLookup = (): UseIsbnLookupReturn => {
     try {
       const result =
         (await tryNdl(normalized)) ?? (await tryGoogleBooks(normalized));
-      if (requestId !== latestRequestIdRef.current) return;
+      if (requestId !== latestRequestIdRef.current) return null;
       if (result == null) {
         setState({ status: "error", message: "書籍が見つかりませんでした" });
-        return;
+        return null;
       }
       setState({ status: "success", result });
+      return result;
     } catch {
-      if (requestId !== latestRequestIdRef.current) return;
+      if (requestId !== latestRequestIdRef.current) return null;
       setState({ status: "error", message: "取得に失敗しました" });
+      return null;
     }
   };
 

--- a/src/features/books/useIsbnLookup.ts
+++ b/src/features/books/useIsbnLookup.ts
@@ -11,6 +11,13 @@ type IsbnLookupState =
   | { status: "success"; result: IsbnLookupResult }
   | { status: "error"; message: string };
 
+type OpenBdBook = {
+  summary: {
+    title: string;
+    author: string;
+  };
+} | null;
+
 type GoogleBooksResponse = {
   items?: {
     volumeInfo: {
@@ -25,6 +32,40 @@ type UseIsbnLookupReturn = {
   lookup: (isbn: string) => Promise<void>;
 };
 
+const parseOpenBdAuthors = (author: string): string[] =>
+  author
+    .split(/[／/]/)
+    .map((a) => a.trim())
+    .filter(Boolean);
+
+const tryOpenBd = async (isbn: string): Promise<IsbnLookupResult | null> => {
+  const response = await fetch(`https://api.openbd.jp/v1/get?isbn=${isbn}`);
+  const data = (await response.json()) as OpenBdBook[];
+  const book = data[0];
+  if (book == null) return null;
+  return {
+    title: book.summary.title,
+    authorNames: book.summary.author
+      ? parseOpenBdAuthors(book.summary.author)
+      : [],
+  };
+};
+
+const tryGoogleBooks = async (
+  isbn: string,
+): Promise<IsbnLookupResult | null> => {
+  const response = await fetch(
+    `https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}`,
+  );
+  const data = (await response.json()) as GoogleBooksResponse;
+  if (!data.items || data.items.length === 0) return null;
+  const volumeInfo = data.items[0].volumeInfo;
+  return {
+    title: volumeInfo.title,
+    authorNames: volumeInfo.authors ?? [],
+  };
+};
+
 export const useIsbnLookup = (): UseIsbnLookupReturn => {
   const [state, setState] = useState<IsbnLookupState>({ status: "idle" });
 
@@ -32,22 +73,13 @@ export const useIsbnLookup = (): UseIsbnLookupReturn => {
     const normalized = isbn.replace(/-/g, "");
     setState({ status: "loading" });
     try {
-      const response = await fetch(
-        `https://www.googleapis.com/books/v1/volumes?q=isbn:${normalized}`,
-      );
-      const data = (await response.json()) as GoogleBooksResponse;
-      if (!data.items || data.items.length === 0) {
+      const result =
+        (await tryOpenBd(normalized)) ?? (await tryGoogleBooks(normalized));
+      if (result == null) {
         setState({ status: "error", message: "書籍が見つかりませんでした" });
         return;
       }
-      const volumeInfo = data.items[0].volumeInfo;
-      setState({
-        status: "success",
-        result: {
-          title: volumeInfo.title,
-          authorNames: volumeInfo.authors ?? [],
-        },
-      });
+      setState({ status: "success", result });
     } catch {
       setState({ status: "error", message: "取得に失敗しました" });
     }

--- a/src/features/books/useIsbnLookup.ts
+++ b/src/features/books/useIsbnLookup.ts
@@ -72,13 +72,13 @@ export const useIsbnLookup = (): UseIsbnLookupReturn => {
   const latestRequestIdRef = useRef(0);
 
   const lookup = async (isbn: string): Promise<IsbnLookupResult | null> => {
+    latestRequestIdRef.current += 1;
+    const requestId = latestRequestIdRef.current;
     if (!isValidIsbn13(isbn)) {
       setState({ status: "error", message: "ISBNが不正です" });
       return null;
     }
     const normalized = normalizeIsbn(isbn);
-    latestRequestIdRef.current += 1;
-    const requestId = latestRequestIdRef.current;
     setState({ status: "loading" });
     try {
       const result =

--- a/src/features/books/useIsbnLookup.ts
+++ b/src/features/books/useIsbnLookup.ts
@@ -11,13 +11,6 @@ type IsbnLookupState =
   | { status: "success"; result: IsbnLookupResult }
   | { status: "error"; message: string };
 
-type OpenBdBook = {
-  summary: {
-    title: string;
-    author: string;
-  };
-} | null;
-
 type GoogleBooksResponse = {
   items?: {
     volumeInfo: {
@@ -32,23 +25,26 @@ type UseIsbnLookupReturn = {
   lookup: (isbn: string) => Promise<void>;
 };
 
-const parseOpenBdAuthors = (author: string): string[] =>
-  author
-    .split(/[／/]/)
-    .map((a) => a.trim())
+const tryNdl = async (isbn: string): Promise<IsbnLookupResult | null> => {
+  const response = await fetch(
+    `https://ndlsearch.ndl.go.jp/api/opensearch?isbn=${isbn}`,
+  );
+  const xmlText = await response.text();
+  const parser = new DOMParser();
+  const xml = parser.parseFromString(xmlText, "text/xml");
+  const items = xml.querySelectorAll("item");
+  if (items.length === 0) return null;
+  const item = items[0];
+  const title = item.querySelector("title")?.textContent ?? "";
+  if (!title) return null;
+  const creatorElements = item.getElementsByTagNameNS(
+    "http://purl.org/dc/elements/1.1/",
+    "creator",
+  );
+  const authorNames = Array.from(creatorElements)
+    .map((el) => el.textContent)
     .filter(Boolean);
-
-const tryOpenBd = async (isbn: string): Promise<IsbnLookupResult | null> => {
-  const response = await fetch(`https://api.openbd.jp/v1/get?isbn=${isbn}`);
-  const data = (await response.json()) as OpenBdBook[];
-  const book = data[0];
-  if (book == null) return null;
-  return {
-    title: book.summary.title,
-    authorNames: book.summary.author
-      ? parseOpenBdAuthors(book.summary.author)
-      : [],
-  };
+  return { title, authorNames };
 };
 
 const tryGoogleBooks = async (
@@ -74,7 +70,7 @@ export const useIsbnLookup = (): UseIsbnLookupReturn => {
     setState({ status: "loading" });
     try {
       const result =
-        (await tryOpenBd(normalized)) ?? (await tryGoogleBooks(normalized));
+        (await tryNdl(normalized)) ?? (await tryGoogleBooks(normalized));
       if (result == null) {
         setState({ status: "error", message: "書籍が見つかりませんでした" });
         return;

--- a/src/features/books/useIsbnLookup.ts
+++ b/src/features/books/useIsbnLookup.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 type IsbnLookupResult = {
   title: string;
@@ -29,6 +29,9 @@ const tryNdl = async (isbn: string): Promise<IsbnLookupResult | null> => {
   const response = await fetch(
     `https://ndlsearch.ndl.go.jp/api/opensearch?isbn=${isbn}`,
   );
+  if (!response.ok) {
+    throw new Error(`NDL API error: ${String(response.status)}`);
+  }
   const xmlText = await response.text();
   const parser = new DOMParser();
   const xml = parser.parseFromString(xmlText, "text/xml");
@@ -53,6 +56,9 @@ const tryGoogleBooks = async (
   const response = await fetch(
     `https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}`,
   );
+  if (!response.ok) {
+    throw new Error(`Google Books API error: ${String(response.status)}`);
+  }
   const data = (await response.json()) as GoogleBooksResponse;
   if (!data.items || data.items.length === 0) return null;
   const volumeInfo = data.items[0].volumeInfo;
@@ -64,19 +70,24 @@ const tryGoogleBooks = async (
 
 export const useIsbnLookup = (): UseIsbnLookupReturn => {
   const [state, setState] = useState<IsbnLookupState>({ status: "idle" });
+  const latestRequestIdRef = useRef(0);
 
   const lookup = async (isbn: string): Promise<void> => {
     const normalized = isbn.replace(/-/g, "");
+    latestRequestIdRef.current += 1;
+    const requestId = latestRequestIdRef.current;
     setState({ status: "loading" });
     try {
       const result =
         (await tryNdl(normalized)) ?? (await tryGoogleBooks(normalized));
+      if (requestId !== latestRequestIdRef.current) return;
       if (result == null) {
         setState({ status: "error", message: "書籍が見つかりませんでした" });
         return;
       }
       setState({ status: "success", result });
     } catch {
+      if (requestId !== latestRequestIdRef.current) return;
       setState({ status: "error", message: "取得に失敗しました" });
     }
   };

--- a/src/features/books/useIsbnLookup.ts
+++ b/src/features/books/useIsbnLookup.ts
@@ -26,9 +26,7 @@ type UseIsbnLookupReturn = {
 };
 
 const tryNdl = async (isbn: string): Promise<IsbnLookupResult | null> => {
-  const response = await fetch(
-    `https://ndlsearch.ndl.go.jp/api/opensearch?isbn=${isbn}`,
-  );
+  const response = await fetch(`/ndl-proxy/api/opensearch?isbn=${isbn}`);
   if (!response.ok) {
     throw new Error(`NDL API error: ${String(response.status)}`);
   }

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,9 @@
 {
-  "rewrites": [{ "source": "/:path*", "destination": "/index.html" }]
+  "rewrites": [
+    {
+      "source": "/ndl-proxy/:path*",
+      "destination": "https://ndlsearch.ndl.go.jp/:path*"
+    },
+    { "source": "/:path*", "destination": "/index.html" }
+  ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,8 +33,26 @@ function excludeMockServiceWorker(): Plugin {
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  server: { port: 3000 },
-  preview: { port: 4173 },
+  server: {
+    port: 3000,
+    proxy: {
+      "/ndl-proxy": {
+        target: "https://ndlsearch.ndl.go.jp",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/ndl-proxy/, ""),
+      },
+    },
+  },
+  preview: {
+    port: 4173,
+    proxy: {
+      "/ndl-proxy": {
+        target: "https://ndlsearch.ndl.go.jp",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/ndl-proxy/, ""),
+      },
+    },
+  },
   plugins: [
     // Please make sure that '@tanstack/router-plugin' is passed before '@vitejs/plugin-react'
     tanstackRouter({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,27 +31,23 @@ function excludeMockServiceWorker(): Plugin {
   };
 }
 
+const NDL_PROXY_CONFIG = {
+  "/ndl-proxy": {
+    target: "https://ndlsearch.ndl.go.jp",
+    changeOrigin: true,
+    rewrite: (path: string) => path.replace(/^\/ndl-proxy/, ""),
+  },
+};
+
 // https://vitejs.dev/config/
 export default defineConfig({
   server: {
     port: 3000,
-    proxy: {
-      "/ndl-proxy": {
-        target: "https://ndlsearch.ndl.go.jp",
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/ndl-proxy/, ""),
-      },
-    },
+    proxy: NDL_PROXY_CONFIG,
   },
   preview: {
     port: 4173,
-    proxy: {
-      "/ndl-proxy": {
-        target: "https://ndlsearch.ndl.go.jp",
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/ndl-proxy/, ""),
-      },
-    },
+    proxy: NDL_PROXY_CONFIG,
   },
   plugins: [
     // Please make sure that '@tanstack/router-plugin' is passed before '@vitejs/plugin-react'


### PR DESCRIPTION
## Summary
This PR adds an ISBN lookup feature that allows users to automatically populate book title and author fields by searching the Google Books API. The feature is currently enabled only in the book add form.

## Key Changes
- **New `useIsbnLookup` hook**: Implements ISBN lookup functionality using the Google Books API
  - Normalizes ISBN input by removing hyphens
  - Handles success, error, and loading states
  - Returns book title and author names from the API response
  - Gracefully handles missing data (e.g., absent authors field)

- **Enhanced `BookForm` component**: 
  - Added optional `enableIsbnLookup` prop to conditionally enable the feature
  - Integrated ISBN lookup button with search icon next to the ISBN input field
  - Auto-populates title field from lookup results
  - Matches returned author names against existing authors in the system and auto-selects them
  - Displays error messages when lookup fails or book is not found
  - Shows loading state on the search button during API calls

- **Updated `BookAddButton`**: Enables ISBN lookup feature when creating new books

- **Comprehensive test coverage**: Added 127 lines of tests covering:
  - Initial idle state
  - Successful lookups with title and author extraction
  - Handling missing authors field
  - Error states (empty results, missing items, network failures)

## Implementation Details
- ISBN normalization removes hyphens before API calls to handle various ISBN formats
- Author matching is case-insensitive to improve matching accuracy
- The feature gracefully degrades if no matching authors are found in the system
- Error messages are user-friendly and displayed in Japanese

https://claude.ai/code/session_01R4X5UDqrdKvL8CaSxfYoVX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 書籍フォームにオプションのISBN検索を追加。検索ボタン、読み込みインジケータ、エラー表示で外部からタイトル／著者を取得してフォームを自動更新。追加ボタンからISBN検索を有効化可能。
  * ISBNの正規化と13桁検証ユーティリティを追加。
* **Tests**
  * ISBN検索フックの包括的テストを追加（各API応答、エラー、並行リクエストを検証）。
* **Documentation**
  * NDLプロキシ運用手順をREADMEと計画ドキュメントに追記。
* **Chores**
  * 開発／プレビュー／本番向けのプロキシ・ルーティング設定とCI関連設定を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->