### PR TITLE
Add author creation from book form

### DIFF
--- a/.agent/plans/20260417-add-author-from-book-form.md
+++ b/.agent/plans/20260417-add-author-from-book-form.md
@@ -1,0 +1,511 @@
+# Add author creation from book form
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Refer to `.agent/PLANS.md` for the full requirements this document must satisfy.
+
+
+## Purpose / Big Picture
+
+Currently, when a user edits or creates a book and cannot find the desired author in the author selection field, they must navigate away to the `/authors` page, create the author there, and come back to the book form. This is disruptive.
+
+After this change, users will be able to type an author name in the author field of the book form. If no existing author matches, a "+ Create <name>" option will appear in the dropdown. Selecting it marks the author as "pending" (no API call yet). When the user submits the book form (either "Save" in the edit view or "追加" in the add modal), any pending authors are created via the GraphQL `createAuthor` mutation first, and then the book is saved with the resulting real author IDs.
+
+To see it working: open a book's edit page (`/books/:id/edit`) or the book-add modal on `/books/`. Type a new author name in the author field. Select "+ Create <name>". The author appears as a pill. Press Save / 追加. The book is saved and the new author now exists.
+
+
+## Progress
+
+- [x] (2026-04-17) Create feature branch `feature/add-author-from-book-form`
+- [ ] Replace `MultiSelect` author field in `BookForm.tsx` with a Combobox-based creatable component
+- [ ] Create `src/features/books/resolvePendingAuthors.ts`
+- [ ] Update `BookDetailEdit.tsx` to resolve pending authors before calling `updateBook`
+- [ ] Update `BookAddButton.tsx` to resolve pending authors before calling `createBook`
+- [ ] Update `BookForm.test.tsx` (mock `useCreateAuthor` if needed; verify existing tests pass)
+- [ ] Run `npm run test && npm run typecheck && npm run lint` and fix any issues
+- [ ] Commit
+
+
+## Surprises & Discoveries
+
+(none yet)
+
+
+## Decision Log
+
+- Decision: Use Mantine `Combobox` primitives (`useCombobox`, `Combobox`, `PillsInput`, `Pill`) instead of `MultiSelect` with a `filter` trick.
+  Rationale: The official Mantine MultiSelectCreatable example uses Combobox primitives. This is the documented, stable approach for creatable multi-selects in Mantine 7/8. Using `MultiSelect` with synthetic `__create__:` values in the `filter` prop would be fragile and undocumented.
+  Date/Author: 2026-04-17
+
+- Decision: Defer author creation to form submit time ("deferred creation"), not at the moment the user selects the "+ Create" option.
+  Rationale: The user requested that pressing the book save button creates authors and saves the book together. Immediate creation on selection would create orphan authors if the user abandons the form.
+  Date/Author: 2026-04-17
+
+- Decision: Represent pending (not-yet-created) authors as `{ id: '__pending__:<name>', name: '<name>' }` in the form state.
+  Rationale: This piggybacks on the existing `Author` type without schema changes. The `__pending__:` prefix is unique enough to distinguish from real UUIDs. The prefix is stripped and replaced with the real ID in `resolvePendingAuthors` at submit time.
+  Date/Author: 2026-04-17
+
+
+## Outcomes & Retrospective
+
+(not yet completed)
+
+
+## Context and Orientation
+
+This is a React + TypeScript frontend project. The UI library is Mantine 8 (`@mantine/core` 8.3.18). Server state is managed with React Query (`@tanstack/react-query` 5). The GraphQL client is `graphql-request` with generated typed SDK in `src/generated/graphql-request.ts`.
+
+Key files:
+
+- `src/features/books/BookForm.tsx` — A custom hook `useBookForm` that renders the entire book form as a `ReactElement` and returns it together with a `submitForm` handler. The author field is currently a Mantine `MultiSelect`. This is the file where the creatable author field will be implemented.
+
+- `src/features/books/BookDetailEdit.tsx` — The book edit page component. Uses `useBookForm` and calls `useUpdateBook` on submit. This must be updated to resolve pending authors before calling `updateBook`.
+
+- `src/features/books/BookAddButton.tsx` — The book creation modal component. Uses `useBookForm` and calls `useCreateBook` on submit. This must also be updated to resolve pending authors.
+
+- `src/compoments/hooks/useCreateAuthor.ts` — A React Query mutation hook that calls the `createAuthor` GraphQL mutation and invalidates the `["authors"]` query cache. Returns `{ mutateAsync, isPending, ... }`. The `mutateAsync` function takes `{ name: string }` and returns `{ createAuthor: { id: string } }`.
+
+- `src/compoments/hooks/useAuthors.ts` — A React Query query hook that fetches all authors. Returns `{ data: { authors: Author[] }, isLoading, error }`.
+
+- `src/features/books/entity/Author.ts` — The `Author` type: `{ id: string; name: string }`.
+
+- `src/features/books/BookForm.test.tsx` — Vitest unit tests for `useBookForm`. Currently mocks `useAuthors`. Will need to also mock `useCreateAuthor` once it is imported by `BookForm.tsx`.
+
+The Mantine Combobox API (relevant to this plan):
+
+  `useCombobox(options)` — creates a combobox store. Options include `onDropdownClose` and `onDropdownOpen` callbacks.
+
+  `<Combobox store={...} onOptionSubmit={handler}>` — wraps the entire combobox. `onOptionSubmit` receives the `value` string of the selected option.
+
+  `<Combobox.DropdownTarget>` — wraps the trigger element (the input).
+
+  `<PillsInput label="..." error={...}>` — a text input that renders pills inside it. Acts as the visible input for the combobox.
+
+  `<Pill.Group>` — container for pills inside `PillsInput`.
+
+  `<Pill withRemoveButton onRemove={...}>` — a removable pill (chip).
+
+  `<Combobox.EventsTarget>` — wraps the actual text field inside `PillsInput`.
+
+  `<PillsInput.Field>` — the text input element. Accepts `value`, `onChange`, `onFocus`, `onBlur`, `onKeyDown`.
+
+  `<Combobox.Dropdown>` — the dropdown container.
+
+  `<Combobox.Options>` — the options list container.
+
+  `<Combobox.Option value="...">` — a single option. The `value` string is passed to `onOptionSubmit`.
+
+  `<CheckIcon size={12} />` — imported from `@mantine/core`, used to mark active (already-selected) options.
+
+
+## Plan of Work
+
+### Step 1 — Replace the author field in `BookForm.tsx`
+
+File: `src/features/books/BookForm.tsx`
+
+Add the following imports (merge with existing import from `@mantine/core`):
+
+    CheckIcon, Combobox, Group, Pill, PillsInput, useCombobox
+
+Add to the React import: `useState`.
+
+Add a new import at the top:
+
+    import { useCreateAuthor } from '../../compoments/hooks/useCreateAuthor';
+
+Note: `useCreateAuthor` is imported here only so that `BookForm.test.tsx` can mock it without changing anything else. `BookForm.tsx` does NOT call it; the pending author resolution happens in `BookDetailEdit` and `BookAddButton`.
+
+Wait — actually `BookForm.tsx` does NOT need to import `useCreateAuthor` at all. Pending authors are represented as `{ id: '__pending__:<name>', name }` in the form state, and the actual creation is done by the callers. `BookForm.tsx` only needs `useState` and the Combobox imports.
+
+Inside `useBookForm`, after the existing `useAuthors` call, add:
+
+    const [authorSearch, setAuthorSearch] = useState('');
+
+    const combobox = useCombobox({
+      onDropdownClose: () => combobox.resetSelectedOption(),
+      onDropdownOpen: () => combobox.updateSelectedOptionIndex('active'),
+    });
+
+    const exactAuthorMatch = data.authors.some(
+      (a) => a.name === authorSearch,
+    );
+
+    const handleAuthorSelect = (val: string) => {
+      setAuthorSearch('');
+      if (val === '$create') {
+        const name = authorSearch;
+        form.setFieldValue('authors', [
+          ...form.values.authors,
+          { id: `__pending__:${name}`, name },
+        ]);
+      } else {
+        const already = form.values.authors.some((a) => a.id === val);
+        if (already) {
+          form.setFieldValue(
+            'authors',
+            form.values.authors.filter((a) => a.id !== val),
+          );
+        } else {
+          const author = data.authors.find((a) => a.id === val);
+          if (author) {
+            form.setFieldValue('authors', [...form.values.authors, author]);
+          }
+        }
+      }
+    };
+
+    const handleAuthorRemove = (id: string) => {
+      form.setFieldValue(
+        'authors',
+        form.values.authors.filter((a) => a.id !== id),
+      );
+    };
+
+Replace the `<MultiSelect ... />` JSX block (currently lines 135–153) with:
+
+    <Combobox store={combobox} onOptionSubmit={handleAuthorSelect}>
+      <Combobox.DropdownTarget>
+        <PillsInput
+          label="著者"
+          onClick={() => combobox.openDropdown()}
+          error={form.errors.authors as string | undefined}
+        >
+          <Pill.Group>
+            {form.values.authors.map((author) => (
+              <Pill
+                key={author.id}
+                withRemoveButton
+                onRemove={() => handleAuthorRemove(author.id)}
+              >
+                {author.name}
+              </Pill>
+            ))}
+            <Combobox.EventsTarget>
+              <PillsInput.Field
+                onFocus={() => combobox.openDropdown()}
+                onBlur={() => combobox.closeDropdown()}
+                value={authorSearch}
+                placeholder="著者を検索"
+                onChange={(e) => {
+                  combobox.updateSelectedOptionIndex();
+                  setAuthorSearch(e.currentTarget.value);
+                }}
+                onKeyDown={(e) => {
+                  if (
+                    e.key === 'Backspace' &&
+                    authorSearch.length === 0 &&
+                    form.values.authors.length > 0
+                  ) {
+                    e.preventDefault();
+                    handleAuthorRemove(
+                      form.values.authors[form.values.authors.length - 1].id,
+                    );
+                  }
+                }}
+              />
+            </Combobox.EventsTarget>
+          </Pill.Group>
+        </PillsInput>
+      </Combobox.DropdownTarget>
+
+      <Combobox.Dropdown>
+        <Combobox.Options>
+          {data.authors
+            .filter((a) =>
+              a.name.toLowerCase().includes(authorSearch.trim().toLowerCase()),
+            )
+            .map((author) => (
+              <Combobox.Option
+                value={author.id}
+                key={author.id}
+                active={form.values.authors.some((a) => a.id === author.id)}
+              >
+                <Group gap="sm">
+                  {form.values.authors.some((a) => a.id === author.id) && (
+                    <CheckIcon size={12} />
+                  )}
+                  <span>{author.name}</span>
+                </Group>
+              </Combobox.Option>
+            ))}
+
+          {!exactAuthorMatch && authorSearch.trim().length > 0 && (
+            <Combobox.Option value="$create">
+              + Create {authorSearch}
+            </Combobox.Option>
+          )}
+        </Combobox.Options>
+      </Combobox.Dropdown>
+    </Combobox>
+
+Remove `MultiSelect` from the `@mantine/core` import line (it is no longer used). Keep all other existing imports.
+
+The `bookFormSchema` Zod schema already validates `authors` as `z.array(z.object({ id: z.string(), name: z.string() })).nonempty()`. The `__pending__:` prefix is a plain string so validation passes unchanged.
+
+
+### Step 3 — Create `resolvePendingAuthors.ts`
+
+Create a new file `src/features/books/resolvePendingAuthors.ts`:
+
+    import type { Author } from './entity/Author';
+
+    export const resolvePendingAuthors = async (
+      authors: Author[],
+      createAuthor: (name: string) => Promise<string>,
+    ): Promise<Author[]> => {
+      return Promise.all(
+        authors.map(async (author) => {
+          if (author.id.startsWith('__pending__:')) {
+            const id = await createAuthor(author.name);
+            return { id, name: author.name };
+          }
+          return author;
+        }),
+      );
+    };
+
+`Author` is `{ id: string; name: string }` from `src/features/books/entity/Author.ts`.
+
+`createAuthor` is an async callback that creates one author by name and returns its real ID (a string). This keeps the utility free of any React hooks, making it easy to unit-test independently.
+
+
+### Step 4 — Update `BookDetailEdit.tsx`
+
+File: `src/features/books/BookDetailEdit.tsx`
+
+Add imports:
+
+    import { useCreateAuthor } from '../../compoments/hooks/useCreateAuthor';
+    import { resolvePendingAuthors } from './resolvePendingAuthors';
+
+Inside the `BookDetailEdit` component, after the existing hook calls, add:
+
+    const createAuthorMutation = useCreateAuthor();
+
+Replace the `handleSubmit` function body with:
+
+    const handleSubmit = async (values: BookFormValues) => {
+      const resolvedAuthors = await resolvePendingAuthors(
+        values.authors,
+        async (name) => {
+          const result = await createAuthorMutation.mutateAsync({ name });
+          return result.createAuthor.id;
+        },
+      );
+      const bookData = {
+        id: book.id,
+        title: values.title,
+        isbn: values.isbn,
+        read: values.read,
+        owned: values.owned,
+        priority: values.priority,
+        format: values.format,
+        store: values.store,
+        authorIds: resolvedAuthors.map((a) => a.id),
+      };
+      await updateBookMutation.mutateAsync(bookData);
+      await navigate({ to: `/books/$id`, params: { id: book.id } });
+      showNotification({ message: '更新しました', color: 'teal' });
+    };
+
+
+### Step 5 — Update `BookAddButton.tsx`
+
+File: `src/features/books/BookAddButton.tsx`
+
+Add imports:
+
+    import { useCreateAuthor } from '../../compoments/hooks/useCreateAuthor';
+    import { resolvePendingAuthors } from './resolvePendingAuthors';
+
+Inside `BookAddButton`, after the `createBookMutation` hook call, add:
+
+    const createAuthorMutation = useCreateAuthor();
+
+Replace the `submitBook` function body with:
+
+    const submitBook = async (value: BookFormValues) => {
+      if (createBookMutation.isPending) return;
+      const resolvedAuthors = await resolvePendingAuthors(
+        value.authors,
+        async (name) => {
+          const result = await createAuthorMutation.mutateAsync({ name });
+          return result.createAuthor.id;
+        },
+      );
+      const { authors: _authors, ...rest } = value;
+      const bookData = {
+        ...rest,
+        authorIds: resolvedAuthors.map((a) => a.id),
+      };
+      try {
+        const result = await createBookMutation.mutateAsync(bookData);
+        setOpen(false);
+        showNotification({
+          message: (
+            <>
+              <div>{value.title}を追加しました</div>
+              <LinkButton
+                linkOptions={{
+                  to: '/books/$id',
+                  params: { id: result.createBook.id },
+                }}
+              >
+                Move
+              </LinkButton>
+            </>
+          ),
+          color: 'teal',
+        });
+      } catch (error) {
+        showNotification({
+          message: `Failed to create book: ${String(error)}`,
+          color: 'red',
+        });
+      }
+    };
+
+
+### Step 6 — Update `BookForm.test.tsx`
+
+The test file mocks `useAuthors` but not `useCreateAuthor`. Since `BookForm.tsx` no longer imports `useCreateAuthor`, no additional mock is needed for that hook in `BookForm.test.tsx`.
+
+However, the existing test "renders all form fields" checks for `著者` by role. After the change, the author field is no longer a `MultiSelect` but a `PillsInput`. Verify the test still finds the label "著者" — Mantine's `PillsInput` renders a `<label>著者</label>` which should be discoverable via `findByLabelText` or similar. If any test breaks, fix it to query the field in a way consistent with the new Combobox-based component.
+
+The test for `combobox` (portals) in Mantine may require `userEvent` interactions; refer to `CLAUDE.md` for Mantine testing docs links if needed.
+
+
+### Step 7 — Run checks and commit
+
+From the repository root, run:
+
+    npm run test
+    npm run typecheck
+    npm run lint
+
+Fix any errors. Then commit:
+
+    git add src/features/books/BookForm.tsx \
+            src/features/books/resolvePendingAuthors.ts \
+            src/features/books/BookDetailEdit.tsx \
+            src/features/books/BookAddButton.tsx \
+            src/features/books/BookForm.test.tsx
+    git commit -m "Add author creation from book form"
+
+
+## Concrete Steps
+
+All commands run from `/home/hiterm/ghq/github.com/hiterm/bookshelf`.
+
+    git switch -c feature/add-author-from-book-form
+
+Edit files as described in Plan of Work above.
+
+    npm run test
+    # Expected: all existing tests pass; no new failures
+
+    npm run typecheck
+    # Expected: no TypeScript errors
+
+    npm run lint
+    # Expected: no ESLint or Biome warnings/errors
+
+    git add <files>
+    git commit -m "Add author creation from book form"
+
+
+## Validation and Acceptance
+
+Start the dev server (`npm start`) and open the app in a browser.
+
+Scenario A — Book edit:
+1. Navigate to an existing book's edit page (`/books/:id/edit`).
+2. In the "著者" field, type a name that does not exist (e.g., "テスト著者").
+3. The dropdown shows "+ Create テスト著者".
+4. Click it. The name appears as a pill in the author field.
+5. Press "Save". The book saves successfully and navigates to the book detail page.
+6. Navigate to `/authors` and confirm "テスト著者" now appears in the author list.
+
+Scenario B — Book add:
+1. Click the "追加" button on `/books/`.
+2. In the author field, type a name that does not exist.
+3. The dropdown shows "+ Create <name>".
+4. Select it. The pill appears.
+5. Fill in a title and press "追加". The book is created and a success notification appears.
+6. Navigate to `/authors` and confirm the new author exists.
+
+Scenario C — Existing author:
+1. In either form, type an existing author's name.
+2. Confirm the "+ Create" option does NOT appear, only the existing author option.
+
+Scenario D — Tests:
+    npm run test
+All tests pass.
+
+
+## Idempotence and Recovery
+
+Each file edit is a direct replacement; re-applying the same change is safe. If `npm run test` fails, read the error output, fix the relevant file, and re-run. No database migrations or destructive operations are involved.
+
+
+## Artifacts and Notes
+
+Official Mantine MultiSelectCreatable example (provided by user, Mantine 8 compatible):
+
+    import { CheckIcon, Combobox, Group, Pill, PillsInput, useCombobox } from '@mantine/core';
+
+    const groceries = ['🍎 Apples', '🍌 Bananas', ...];
+
+    export function MultiSelectCreatable() {
+      const combobox = useCombobox({
+        onDropdownClose: () => combobox.resetSelectedOption(),
+        onDropdownOpen: () => combobox.updateSelectedOptionIndex('active'),
+      });
+      const [search, setSearch] = useState('');
+      const [data, setData] = useState(groceries);
+      const [value, setValue] = useState<string[]>([]);
+      const exactOptionMatch = data.some((item) => item === search);
+
+      const handleValueSelect = (val: string) => {
+        setSearch('');
+        if (val === '$create') {
+          setData((current) => [...current, search]);
+          setValue((current) => [...current, search]);
+        } else {
+          setValue((current) =>
+            current.includes(val) ? current.filter((v) => v !== val) : [...current, val]
+          );
+        }
+      };
+      // ... PillsInput + Combobox JSX as shown in the official example
+    }
+
+Key adaptation for this project: instead of `setValue` directly with the search string, we set `form.values.authors` with `{ id: '__pending__:<name>', name }` and defer the actual `createAuthor` API call to submit time.
+
+
+## Interfaces and Dependencies
+
+In `src/features/books/resolvePendingAuthors.ts`, export:
+
+    export const resolvePendingAuthors: (
+      authors: Author[],
+      createAuthor: (name: string) => Promise<string>,
+    ) => Promise<Author[]>
+
+Where `Author` is `import type { Author } from './entity/Author'` (the type `{ id: string; name: string }`).
+
+In `src/compoments/hooks/useCreateAuthor.ts` (unchanged), the existing hook returns:
+
+    {
+      mutateAsync: (input: { name: string }) => Promise<{ createAuthor: { id: string } }>,
+      isPending: boolean,
+      // ...other React Query mutation fields
+    }
+
+New Mantine imports used in `BookForm.tsx`:
+
+    CheckIcon, Combobox, Group, Pill, PillsInput, useCombobox  — from '@mantine/core'
+    useState  — from 'react'
+
+`MultiSelect` is removed from `BookForm.tsx` imports after this change.

--- a/.agent/plans/20260417-add-author-from-book-form.md
+++ b/.agent/plans/20260417-add-author-from-book-form.md
@@ -17,7 +17,9 @@ To see it working: open a book's edit page (`/books/:id/edit`) or the book-add m
 ## Progress
 
 - [x] (2026-04-17) Create feature branch `feature/add-author-from-book-form`
-- [ ] Replace `MultiSelect` author field in `BookForm.tsx` with a Combobox-based creatable component
+- [x] (2026-04-17) Rebase onto main (BookForm split refactor merged)
+- [ ] Replace `MultiSelect` author field in `BookUpdateForm.tsx` with a Combobox-based creatable component
+- [ ] Replace `MultiSelect` author field in `BookCreateForm.tsx` with a Combobox-based creatable component
 - [ ] Create `src/features/books/resolvePendingAuthors.ts`
 - [ ] Update `BookDetailEdit.tsx` to resolve pending authors before calling `updateBook`
 - [ ] Update `BookAddButton.tsx` to resolve pending authors before calling `createBook`
@@ -28,7 +30,7 @@ To see it working: open a book's edit page (`/books/:id/edit`) or the book-add m
 
 ## Surprises & Discoveries
 
-(none yet)
+- (2026-04-17) After rebasing, `BookForm.tsx` (the old custom hook `useBookForm`) no longer exists. It was split into two pure UI components: `BookCreateForm.tsx` and `BookUpdateForm.tsx`. Both receive a `form: UseFormReturnType<BookFormValues>` prop. The Combobox replacement must be applied to both files independently.
 
 
 ## Decision Log
@@ -45,6 +47,14 @@ To see it working: open a book's edit page (`/books/:id/edit`) or the book-add m
   Rationale: This piggybacks on the existing `Author` type without schema changes. The `__pending__:` prefix is unique enough to distinguish from real UUIDs. The prefix is stripped and replaced with the real ID in `resolvePendingAuthors` at submit time.
   Date/Author: 2026-04-17
 
+- Decision: Apply the Combobox replacement to both `BookCreateForm.tsx` and `BookUpdateForm.tsx` independently (not a shared component).
+  Rationale: The two forms already differ (BookCreateForm has ISBN lookup, BookUpdateForm does not). Extracting a shared creatable-author component adds indirection; keeping them separate is consistent with the split refactor on main.
+  Date/Author: 2026-04-17
+
+- Decision: Use type narrowing (`typeof form.errors.authors === 'string' ? form.errors.authors : undefined`) instead of `as string | undefined`.
+  Rationale: CLAUDE.md now prohibits `as` type assertions (added in the refactor-form PR merged to main).
+  Date/Author: 2026-04-17
+
 
 ## Outcomes & Retrospective
 
@@ -57,11 +67,13 @@ This is a React + TypeScript frontend project. The UI library is Mantine 8 (`@ma
 
 Key files:
 
-- `src/features/books/BookForm.tsx` — A custom hook `useBookForm` that renders the entire book form as a `ReactElement` and returns it together with a `submitForm` handler. The author field is currently a Mantine `MultiSelect`. This is the file where the creatable author field will be implemented.
+- `src/features/books/BookUpdateForm.tsx` — Pure UI component for the book edit form. Receives `form: UseFormReturnType<BookFormValues>`. The author field is currently a Mantine `MultiSelect`. Used by `BookDetailEdit.tsx`.
 
-- `src/features/books/BookDetailEdit.tsx` — The book edit page component. Uses `useBookForm` and calls `useUpdateBook` on submit. This must be updated to resolve pending authors before calling `updateBook`.
+- `src/features/books/BookCreateForm.tsx` — Pure UI component for the book creation form. Receives `form: UseFormReturnType<BookFormValues>`. Also contains ISBN lookup logic. The author field is currently a Mantine `MultiSelect`. Used by `BookAddButton.tsx`.
 
-- `src/features/books/BookAddButton.tsx` — The book creation modal component. Uses `useBookForm` and calls `useCreateBook` on submit. This must also be updated to resolve pending authors.
+- `src/features/books/BookDetailEdit.tsx` — The book edit page component. Manages `useForm` state and calls `useUpdateBook` on submit. Must be updated to resolve pending authors before calling `updateBook`.
+
+- `src/features/books/BookAddButton.tsx` — The book creation modal component. Manages `useForm` state and calls `useCreateBook` on submit. Must also be updated to resolve pending authors.
 
 - `src/compoments/hooks/useCreateAuthor.ts` — A React Query mutation hook that calls the `createAuthor` GraphQL mutation and invalidates the `["authors"]` query cache. Returns `{ mutateAsync, isPending, ... }`. The `mutateAsync` function takes `{ name: string }` and returns `{ createAuthor: { id: string } }`.
 
@@ -69,7 +81,7 @@ Key files:
 
 - `src/features/books/entity/Author.ts` — The `Author` type: `{ id: string; name: string }`.
 
-- `src/features/books/BookForm.test.tsx` — Vitest unit tests for `useBookForm`. Currently mocks `useAuthors`. Will need to also mock `useCreateAuthor` once it is imported by `BookForm.tsx`.
+- `src/features/books/BookForm.test.tsx` — Vitest unit tests for `BookUpdateForm`. Currently mocks `useAuthors`. Will need to also mock `useCreateAuthor` once the Combobox component imports it (it does not; see Step 1 note).
 
 The Mantine Combobox API (relevant to this plan):
 
@@ -100,25 +112,21 @@ The Mantine Combobox API (relevant to this plan):
 
 ## Plan of Work
 
-### Step 1 — Replace the author field in `BookForm.tsx`
+The Combobox replacement logic is identical in both `BookUpdateForm.tsx` and `BookCreateForm.tsx`. Steps 1 and 2 below describe the change; apply it to each file.
 
-File: `src/features/books/BookForm.tsx`
+### Step 1 — Replace the author field in `BookUpdateForm.tsx`
 
-Add the following imports (merge with existing import from `@mantine/core`):
+File: `src/features/books/BookUpdateForm.tsx`
+
+Add the following to the imports from `@mantine/core` (merge with the existing import):
 
     CheckIcon, Combobox, Group, Pill, PillsInput, useCombobox
 
-Add to the React import: `useState`.
+Add `useState` to the React import (currently `import React from 'react'` — change to `import React, { useState } from 'react'`).
 
-Add a new import at the top:
+Remove `MultiSelect` from the `@mantine/core` import (it is no longer used).
 
-    import { useCreateAuthor } from '../../compoments/hooks/useCreateAuthor';
-
-Note: `useCreateAuthor` is imported here only so that `BookForm.test.tsx` can mock it without changing anything else. `BookForm.tsx` does NOT call it; the pending author resolution happens in `BookDetailEdit` and `BookAddButton`.
-
-Wait — actually `BookForm.tsx` does NOT need to import `useCreateAuthor` at all. Pending authors are represented as `{ id: '__pending__:<name>', name }` in the form state, and the actual creation is done by the callers. `BookForm.tsx` only needs `useState` and the Combobox imports.
-
-Inside `useBookForm`, after the existing `useAuthors` call, add:
+Inside `BookUpdateForm`, after the `useAuthors` call, add:
 
     const [authorSearch, setAuthorSearch] = useState('');
 
@@ -162,14 +170,18 @@ Inside `useBookForm`, after the existing `useAuthors` call, add:
       );
     };
 
-Replace the `<MultiSelect ... />` JSX block (currently lines 135–153) with:
+Replace the `<MultiSelect ... />` JSX block with:
 
     <Combobox store={combobox} onOptionSubmit={handleAuthorSelect}>
       <Combobox.DropdownTarget>
         <PillsInput
           label="著者"
           onClick={() => combobox.openDropdown()}
-          error={form.errors.authors as string | undefined}
+          error={
+            typeof form.errors.authors === 'string'
+              ? form.errors.authors
+              : undefined
+          }
         >
           <Pill.Group>
             {form.values.authors.map((author) => (
@@ -239,9 +251,22 @@ Replace the `<MultiSelect ... />` JSX block (currently lines 135–153) with:
       </Combobox.Dropdown>
     </Combobox>
 
-Remove `MultiSelect` from the `@mantine/core` import line (it is no longer used). Keep all other existing imports.
+Note: `form.errors.authors` uses `typeof` narrowing (not `as`) to satisfy CLAUDE.md's prohibition on `as` type assertions.
 
-The `bookFormSchema` Zod schema already validates `authors` as `z.array(z.object({ id: z.string(), name: z.string() })).nonempty()`. The `__pending__:` prefix is a plain string so validation passes unchanged.
+The `bookFormSchema` Zod schema validates `authors` as `z.array(z.object({ id: z.string(), name: z.string() })).min(1)`. The `__pending__:` prefix is a plain string so validation passes unchanged.
+
+
+### Step 2 — Replace the author field in `BookCreateForm.tsx`
+
+File: `src/features/books/BookCreateForm.tsx`
+
+Apply the exact same Combobox replacement as Step 1. The only difference is that `BookCreateForm` also contains ISBN lookup logic — leave that unchanged. The `useState` for `authorSearch` is in addition to any existing state (there is none in this component currently).
+
+Merge the new Mantine imports (`CheckIcon, Combobox, Group, Pill, PillsInput, useCombobox`) with the existing import from `@mantine/core`. Note that `Group` is already imported in `BookCreateForm.tsx` — do not duplicate it. Remove `MultiSelect` from the import.
+
+Add `useState` to the React import (currently `import React from 'react'`).
+
+The handler functions and JSX are identical to Step 1.
 
 
 ### Step 3 — Create `resolvePendingAuthors.ts`
@@ -279,7 +304,7 @@ Add imports:
     import { useCreateAuthor } from '../../compoments/hooks/useCreateAuthor';
     import { resolvePendingAuthors } from './resolvePendingAuthors';
 
-Inside the `BookDetailEdit` component, after the existing hook calls, add:
+Inside `BookDetailEdit`, after the `updateBookMutation` hook call, add:
 
     const createAuthorMutation = useCreateAuthor();
 
@@ -369,9 +394,9 @@ Replace the `submitBook` function body with:
 
 ### Step 6 — Update `BookForm.test.tsx`
 
-The test file mocks `useAuthors` but not `useCreateAuthor`. Since `BookForm.tsx` no longer imports `useCreateAuthor`, no additional mock is needed for that hook in `BookForm.test.tsx`.
+The test file (`src/features/books/BookForm.test.tsx`) currently tests `BookUpdateForm` and mocks `useAuthors`. Since `BookUpdateForm.tsx` does not import `useCreateAuthor` (pending author resolution happens in `BookDetailEdit.tsx`), no additional mock is needed.
 
-However, the existing test "renders all form fields" checks for `著者` by role. After the change, the author field is no longer a `MultiSelect` but a `PillsInput`. Verify the test still finds the label "著者" — Mantine's `PillsInput` renders a `<label>著者</label>` which should be discoverable via `findByLabelText` or similar. If any test breaks, fix it to query the field in a way consistent with the new Combobox-based component.
+After Step 1, the author field in `BookUpdateForm` changes from `MultiSelect` to a `PillsInput`-based Combobox. The existing tests do not query the author field directly (they query by "書名", "ISBN", checkboxes, and the submit button). Verify all existing tests still pass. If any test breaks due to the `MultiSelect` → `PillsInput` change, update the query to use `findByRole` or `findByLabelText` consistent with the new component.
 
 The test for `combobox` (portals) in Mantine may require `userEvent` interactions; refer to `CLAUDE.md` for Mantine testing docs links if needed.
 
@@ -386,7 +411,8 @@ From the repository root, run:
 
 Fix any errors. Then commit:
 
-    git add src/features/books/BookForm.tsx \
+    git add src/features/books/BookUpdateForm.tsx \
+            src/features/books/BookCreateForm.tsx \
             src/features/books/resolvePendingAuthors.ts \
             src/features/books/BookDetailEdit.tsx \
             src/features/books/BookAddButton.tsx \
@@ -398,7 +424,7 @@ Fix any errors. Then commit:
 
 All commands run from `/home/hiterm/ghq/github.com/hiterm/bookshelf`.
 
-    git switch -c feature/add-author-from-book-form
+Branch already exists: `feature/add-author-from-book-form` (rebased onto main).
 
 Edit files as described in Plan of Work above.
 
@@ -503,9 +529,11 @@ In `src/compoments/hooks/useCreateAuthor.ts` (unchanged), the existing hook retu
       // ...other React Query mutation fields
     }
 
-New Mantine imports used in `BookForm.tsx`:
+New Mantine imports used in both form components:
 
     CheckIcon, Combobox, Group, Pill, PillsInput, useCombobox  — from '@mantine/core'
     useState  — from 'react'
 
-`MultiSelect` is removed from `BookForm.tsx` imports after this change.
+Note: `Group` is already imported in `BookCreateForm.tsx`; do not duplicate it.
+
+`MultiSelect` is removed from both form component imports after this change.

--- a/.agent/plans/20260417-add-author-from-book-form.md
+++ b/.agent/plans/20260417-add-author-from-book-form.md
@@ -18,14 +18,14 @@ To see it working: open a book's edit page (`/books/:id/edit`) or the book-add m
 
 - [x] (2026-04-17) Create feature branch `feature/add-author-from-book-form`
 - [x] (2026-04-17) Rebase onto main (BookForm split refactor merged)
-- [ ] Replace `MultiSelect` author field in `BookUpdateForm.tsx` with a Combobox-based creatable component
-- [ ] Replace `MultiSelect` author field in `BookCreateForm.tsx` with a Combobox-based creatable component
-- [ ] Create `src/features/books/resolvePendingAuthors.ts`
-- [ ] Update `BookDetailEdit.tsx` to resolve pending authors before calling `updateBook`
-- [ ] Update `BookAddButton.tsx` to resolve pending authors before calling `createBook`
-- [ ] Update `BookForm.test.tsx` (mock `useCreateAuthor` if needed; verify existing tests pass)
-- [ ] Run `npm run test && npm run typecheck && npm run lint` and fix any issues
-- [ ] Commit
+- [x] (2026-04-17) Replace `MultiSelect` author field in `BookUpdateForm.tsx` with a Combobox-based creatable component
+- [x] (2026-04-17) Replace `MultiSelect` author field in `BookCreateForm.tsx` with a Combobox-based creatable component
+- [x] (2026-04-17) Create `src/features/books/resolvePendingAuthors.ts`
+- [x] (2026-04-17) Update `BookDetailEdit.tsx` to resolve pending authors before calling `updateBook`
+- [x] (2026-04-17) Update `BookAddButton.tsx` to resolve pending authors before calling `createBook`
+- [x] (2026-04-17) Update `BookForm.test.tsx` (mock `useCreateAuthor` if needed; verify existing tests pass)
+- [x] (2026-04-17) Run `npm run test && npm run typecheck && npm run lint` and fix any issues
+- [x] (2026-04-17) Commit
 
 
 ## Surprises & Discoveries
@@ -58,7 +58,7 @@ To see it working: open a book's edit page (`/books/:id/edit`) or the book-add m
 
 ## Outcomes & Retrospective
 
-(not yet completed)
+Completed 2026-04-17. All 5 files modified as planned; `resolvePendingAuthors.ts` created. No test changes were needed — existing tests passed without mocking `useCreateAuthor` (pending author resolution is in `BookDetailEdit`/`BookAddButton`, not the form components). Two rounds of linter fixes were needed: ESLint required braces on void-returning arrow functions, and Biome then reformatted those to multi-line style.
 
 
 ## Context and Orientation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,10 @@
 - Think and work in **English**
 - Use the same language as the user for confirmations and final reports
 
+## Testing Policy
+
+- When implementing a new feature, always implement tests for it.
+
 ## Testing Mantine Components
 
 When writing tests for Mantine components, refer to these docs as needed:

--- a/src/features/books/AuthorsCombobox.test.tsx
+++ b/src/features/books/AuthorsCombobox.test.tsx
@@ -173,7 +173,7 @@ describe("AuthorsCombobox", () => {
   test("removes a pill via remove button", async () => {
     mockMatchMedia();
     const onChange = vi.fn();
-    render(
+    const { container } = render(
       <TestCombobox
         onChange={onChange}
         initial={[{ id: "1", name: "name1" }]}
@@ -183,11 +183,11 @@ describe("AuthorsCombobox", () => {
     const user = userEvent.setup({
       advanceTimers: vi.advanceTimersByTime.bind(vi),
     });
-    // The Pill remove button is aria-hidden; find it via the PillGroup container
-    const input = screen.getByRole("textbox", { name: "著者" });
-    const pillGroup = input.parentElement;
-    const removeButton = pillGroup?.querySelector("button");
-    if (!removeButton) throw new Error("No remove button found in pill group");
+    // Mantine renders the Pill remove button with aria-hidden; query by aria-label attribute.
+    const removeButton = container.querySelector(
+      '[aria-label="Remove author name1"]',
+    );
+    if (!removeButton) throw new Error("Remove button not found");
     await user.click(removeButton);
 
     expect(onChange).toHaveBeenLastCalledWith([]);

--- a/src/features/books/AuthorsCombobox.test.tsx
+++ b/src/features/books/AuthorsCombobox.test.tsx
@@ -13,17 +13,14 @@ const defaultAuthors: Author[] = [
 ];
 
 beforeAll(() => {
+  // Test stub; methods are intentionally no-ops.
+  /* eslint-disable @typescript-eslint/no-empty-function */
   global.ResizeObserver = class ResizeObserver {
-    observe() {
-      // do nothing
-    }
-    unobserve() {
-      // do nothing
-    }
-    disconnect() {
-      // do nothing
-    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
   };
+  /* eslint-enable @typescript-eslint/no-empty-function */
   HTMLElement.prototype.scrollIntoView = vi.fn();
 });
 

--- a/src/features/books/AuthorsCombobox.test.tsx
+++ b/src/features/books/AuthorsCombobox.test.tsx
@@ -1,0 +1,226 @@
+import "@testing-library/jest-dom";
+import { MantineProvider } from "@mantine/core";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React, { useState } from "react";
+import { type Mock, vi } from "vitest";
+import { AuthorsCombobox } from "./AuthorsCombobox";
+import type { Author } from "./entity/Author";
+
+const defaultAuthors: Author[] = [
+  { id: "1", name: "name1" },
+  { id: "2", name: "name2" },
+];
+
+beforeAll(() => {
+  global.ResizeObserver = class ResizeObserver {
+    observe() {
+      // do nothing
+    }
+    unobserve() {
+      // do nothing
+    }
+    disconnect() {
+      // do nothing
+    }
+  };
+  HTMLElement.prototype.scrollIntoView = vi.fn();
+});
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const mockMatchMedia = () => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+};
+
+type TestComboboxProps = {
+  onChange: Mock;
+  initial?: Author[];
+  authors?: Author[];
+  error?: React.ReactNode;
+};
+
+const TestCombobox: React.FC<TestComboboxProps> = ({
+  onChange,
+  initial = [],
+  authors = defaultAuthors,
+  error,
+}) => {
+  const [value, setValue] = useState(initial);
+  return (
+    <MantineProvider env="test">
+      <AuthorsCombobox
+        authors={authors}
+        value={value}
+        onChange={(updated) => {
+          setValue(updated);
+          onChange(updated);
+        }}
+        error={error}
+      />
+    </MantineProvider>
+  );
+};
+
+describe("AuthorsCombobox", () => {
+  test("selects an existing author", async () => {
+    mockMatchMedia();
+    const onChange = vi.fn();
+    render(<TestCombobox onChange={onChange} />);
+
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime.bind(vi),
+    });
+    const input = screen.getByRole("textbox", { name: "著者" });
+    await user.click(input);
+
+    await user.click(await screen.findByRole("option", { name: "name1" }));
+
+    expect(onChange).toHaveBeenLastCalledWith([{ id: "1", name: "name1" }]);
+  });
+
+  test("deselects an already selected author", async () => {
+    mockMatchMedia();
+    const onChange = vi.fn();
+    render(
+      <TestCombobox
+        onChange={onChange}
+        initial={[{ id: "1", name: "name1" }]}
+      />,
+    );
+
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime.bind(vi),
+    });
+    const input = screen.getByRole("textbox", { name: "著者" });
+    await user.click(input);
+
+    await user.click(await screen.findByRole("option", { name: "name1" }));
+
+    expect(onChange).toHaveBeenLastCalledWith([]);
+  });
+
+  test("shows '+ Create' option for non-matching search", async () => {
+    mockMatchMedia();
+    const onChange = vi.fn();
+    render(<TestCombobox onChange={onChange} />);
+
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime.bind(vi),
+    });
+    const input = screen.getByRole("textbox", { name: "著者" });
+    await user.click(input);
+    await user.type(input, "NewAuthor");
+
+    expect(
+      await screen.findByRole("option", { name: "+ Create NewAuthor" }),
+    ).toBeInTheDocument();
+  });
+
+  test("does not show '+ Create' on exact name match", async () => {
+    mockMatchMedia();
+    const onChange = vi.fn();
+    render(<TestCombobox onChange={onChange} />);
+
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime.bind(vi),
+    });
+    const input = screen.getByRole("textbox", { name: "著者" });
+    await user.click(input);
+    await user.type(input, "name1");
+
+    expect(
+      screen.queryByRole("option", { name: "+ Create name1" }),
+    ).not.toBeInTheDocument();
+  });
+
+  test("creates a pending author when '+ Create' is clicked", async () => {
+    mockMatchMedia();
+    const onChange = vi.fn();
+    render(<TestCombobox onChange={onChange} />);
+
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime.bind(vi),
+    });
+    const input = screen.getByRole("textbox", { name: "著者" });
+    await user.click(input);
+    await user.type(input, "NewAuthor");
+
+    await user.click(
+      await screen.findByRole("option", { name: "+ Create NewAuthor" }),
+    );
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      { id: "__pending__:NewAuthor", name: "NewAuthor" },
+    ]);
+  });
+
+  test("removes a pill via remove button", async () => {
+    mockMatchMedia();
+    const onChange = vi.fn();
+    render(
+      <TestCombobox
+        onChange={onChange}
+        initial={[{ id: "1", name: "name1" }]}
+      />,
+    );
+
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime.bind(vi),
+    });
+    // The Pill remove button is aria-hidden; find it via the PillGroup container
+    const input = screen.getByRole("textbox", { name: "著者" });
+    const pillGroup = input.parentElement;
+    const removeButton = pillGroup?.querySelector("button");
+    if (!removeButton) throw new Error("No remove button found in pill group");
+    await user.click(removeButton);
+
+    expect(onChange).toHaveBeenLastCalledWith([]);
+  });
+
+  test("removes last author via Backspace with empty input", async () => {
+    mockMatchMedia();
+    const onChange = vi.fn();
+    render(
+      <TestCombobox
+        onChange={onChange}
+        initial={[{ id: "1", name: "name1" }]}
+      />,
+    );
+
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime.bind(vi),
+    });
+    const input = screen.getByRole("textbox", { name: "著者" });
+    await user.click(input);
+    await user.keyboard("{Backspace}");
+
+    expect(onChange).toHaveBeenLastCalledWith([]);
+  });
+
+  test("shows error message when error prop is set", () => {
+    mockMatchMedia();
+    const onChange = vi.fn();
+    render(<TestCombobox onChange={onChange} error="著者は必須です" />);
+
+    expect(screen.getByText("著者は必須です")).toBeInTheDocument();
+  });
+});

--- a/src/features/books/AuthorsCombobox.tsx
+++ b/src/features/books/AuthorsCombobox.tsx
@@ -80,6 +80,9 @@ export const AuthorsCombobox: React.FC<AuthorsComboboxProps> = ({
               <Pill
                 key={author.id}
                 withRemoveButton
+                removeButtonProps={{
+                  "aria-label": `Remove author ${author.name}`,
+                }}
                 onRemove={() => {
                   handleAuthorRemove(author.id);
                 }}

--- a/src/features/books/AuthorsCombobox.tsx
+++ b/src/features/books/AuthorsCombobox.tsx
@@ -1,0 +1,148 @@
+import {
+  CheckIcon,
+  Combobox,
+  Group,
+  Pill,
+  PillsInput,
+  useCombobox,
+} from "@mantine/core";
+import React, { useState } from "react";
+import { Author } from "./entity/Author";
+
+type AuthorsComboboxProps = {
+  authors: Author[];
+  value: Author[];
+  onChange: (authors: Author[]) => void;
+  error?: React.ReactNode;
+};
+
+export const AuthorsCombobox: React.FC<AuthorsComboboxProps> = ({
+  authors,
+  value,
+  onChange,
+  error,
+}) => {
+  const [authorSearch, setAuthorSearch] = useState("");
+
+  const combobox = useCombobox({
+    onDropdownClose: () => {
+      combobox.resetSelectedOption();
+    },
+    onDropdownOpen: () => {
+      combobox.updateSelectedOptionIndex("active");
+    },
+  });
+
+  const normalizedSearch = authorSearch.trim().toLowerCase();
+  const exactAuthorMatch =
+    normalizedSearch.length > 0 &&
+    (authors.some((a) => a.name.toLowerCase() === normalizedSearch) ||
+      value.some(
+        (a) =>
+          a.id.startsWith("__pending__:") &&
+          a.name.toLowerCase() === normalizedSearch,
+      ));
+
+  const handleAuthorSelect = (val: string) => {
+    setAuthorSearch("");
+    if (val === "$create") {
+      const name = authorSearch.trim();
+      onChange([...value, { id: `__pending__:${name}`, name }]);
+    } else {
+      const already = value.some((a) => a.id === val);
+      if (already) {
+        onChange(value.filter((a) => a.id !== val));
+      } else {
+        const author = authors.find((a) => a.id === val);
+        if (author) {
+          onChange([...value, author]);
+        }
+      }
+    }
+  };
+
+  const handleAuthorRemove = (id: string) => {
+    onChange(value.filter((a) => a.id !== id));
+  };
+
+  return (
+    <Combobox store={combobox} onOptionSubmit={handleAuthorSelect}>
+      <Combobox.DropdownTarget>
+        <PillsInput
+          label="著者"
+          onClick={() => {
+            combobox.openDropdown();
+          }}
+          error={error}
+        >
+          <Pill.Group>
+            {value.map((author) => (
+              <Pill
+                key={author.id}
+                withRemoveButton
+                onRemove={() => {
+                  handleAuthorRemove(author.id);
+                }}
+              >
+                {author.name}
+              </Pill>
+            ))}
+            <Combobox.EventsTarget>
+              <PillsInput.Field
+                onFocus={() => {
+                  combobox.openDropdown();
+                }}
+                onBlur={() => {
+                  combobox.closeDropdown();
+                }}
+                value={authorSearch}
+                placeholder="著者を検索"
+                onChange={(e) => {
+                  combobox.updateSelectedOptionIndex();
+                  setAuthorSearch(e.currentTarget.value);
+                }}
+                onKeyDown={(e) => {
+                  if (
+                    e.key === "Backspace" &&
+                    authorSearch.length === 0 &&
+                    value.length > 0
+                  ) {
+                    e.preventDefault();
+                    handleAuthorRemove(value[value.length - 1].id);
+                  }
+                }}
+              />
+            </Combobox.EventsTarget>
+          </Pill.Group>
+        </PillsInput>
+      </Combobox.DropdownTarget>
+
+      <Combobox.Dropdown>
+        <Combobox.Options>
+          {authors
+            .filter((a) => a.name.toLowerCase().includes(normalizedSearch))
+            .map((author) => (
+              <Combobox.Option
+                value={author.id}
+                key={author.id}
+                active={value.some((a) => a.id === author.id)}
+              >
+                <Group gap="sm">
+                  {value.some((a) => a.id === author.id) && (
+                    <CheckIcon size={12} />
+                  )}
+                  <span>{author.name}</span>
+                </Group>
+              </Combobox.Option>
+            ))}
+
+          {!exactAuthorMatch && normalizedSearch.length > 0 && (
+            <Combobox.Option value="$create">
+              + Create {authorSearch.trim()}
+            </Combobox.Option>
+          )}
+        </Combobox.Options>
+      </Combobox.Dropdown>
+    </Combobox>
+  );
+};

--- a/src/features/books/BookAddButton.tsx
+++ b/src/features/books/BookAddButton.tsx
@@ -4,9 +4,11 @@ import { showNotification } from "@mantine/notifications";
 import { zodResolver } from "mantine-form-zod-resolver";
 import React, { useState } from "react";
 import { LinkButton } from "../../compoments/mantineTsr";
+import { useCreateAuthor } from "../../compoments/hooks/useCreateAuthor";
 import { useCreateBook } from "../../compoments/hooks/useCreateBook";
 import { BookCreateForm } from "./BookCreateForm";
 import { bookFormSchema, BookFormValues } from "./bookFormSchema";
+import { resolvePendingAuthors } from "./resolvePendingAuthors";
 
 export const BookAddButton: React.FC = () => {
   const [open, setOpen] = useState(false);
@@ -20,13 +22,21 @@ export const BookAddButton: React.FC = () => {
   };
 
   const createBookMutation = useCreateBook();
+  const createAuthorMutation = useCreateAuthor();
 
   const submitBook = async (value: BookFormValues) => {
     if (createBookMutation.isPending) return;
-    const { authors, ...rest } = value;
+    const resolvedAuthors = await resolvePendingAuthors(
+      value.authors,
+      async (name) => {
+        const result = await createAuthorMutation.mutateAsync({ name });
+        return result.createAuthor.id;
+      },
+    );
+    const { authors: _authors, ...rest } = value;
     const bookData = {
       ...rest,
-      authorIds: authors.map((author) => author.id),
+      authorIds: resolvedAuthors.map((a) => a.id),
     };
 
     try {

--- a/src/features/books/BookAddButton.tsx
+++ b/src/features/books/BookAddButton.tsx
@@ -26,13 +26,26 @@ export const BookAddButton: React.FC = () => {
 
   const submitBook = async (value: BookFormValues) => {
     if (createBookMutation.isPending) return;
-    const resolvedAuthors = await resolvePendingAuthors(
-      value.authors,
-      async (name) => {
-        const result = await createAuthorMutation.mutateAsync({ name });
-        return result.createAuthor.id;
-      },
-    );
+
+    let resolvedAuthors: Awaited<ReturnType<typeof resolvePendingAuthors>>;
+    try {
+      resolvedAuthors = await resolvePendingAuthors(
+        value.authors,
+        async (name) => {
+          const result = await createAuthorMutation.mutateAsync({ name });
+          return result.createAuthor.id;
+        },
+      );
+    } catch (error) {
+      showNotification({
+        message: `Failed to create author: ${String(error)}`,
+        color: "red",
+      });
+      return;
+    }
+
+    form.setFieldValue("authors", resolvedAuthors);
+
     const { authors: _authors, ...rest } = value;
     const bookData = {
       ...rest,

--- a/src/features/books/BookCreateForm.tsx
+++ b/src/features/books/BookCreateForm.tsx
@@ -1,23 +1,27 @@
 import {
   ActionIcon,
   Checkbox,
+  CheckIcon,
+  Combobox,
   Group,
   Loader,
-  MultiSelect,
   NumberInput,
+  Pill,
+  PillsInput,
   Select,
   Stack,
   Text,
   TextInput,
+  useCombobox,
 } from "@mantine/core";
 import { UseFormReturnType } from "@mantine/form";
 import { IconSearch } from "@tabler/icons-react";
-import React from "react";
+import React, { useState } from "react";
 import { useAuthors } from "../../compoments/hooks/useAuthors";
 import { BookFormValues } from "./bookFormSchema";
+import { Author } from "./entity/Author";
 import { BOOK_FORMAT_VALUE, displayBookFormat } from "./entity/BookFormat";
 import { BOOK_STORE_VALUE, displayBookStore } from "./entity/BookStore";
-import { Author } from "./entity/Author";
 import { useIsbnLookup } from "./useIsbnLookup";
 
 type BookCreateFormProps = {
@@ -27,6 +31,16 @@ type BookCreateFormProps = {
 export const BookCreateForm: React.FC<BookCreateFormProps> = ({ form }) => {
   const { data, isLoading, error } = useAuthors();
   const { state: isbnLookupState, lookup: lookupIsbn } = useIsbnLookup();
+  const [authorSearch, setAuthorSearch] = useState("");
+
+  const combobox = useCombobox({
+    onDropdownClose: () => {
+      combobox.resetSelectedOption();
+    },
+    onDropdownOpen: () => {
+      combobox.updateSelectedOptionIndex("active");
+    },
+  });
 
   const handleIsbnLookup = async () => {
     const result = await lookupIsbn(form.values.isbn);
@@ -58,28 +72,130 @@ export const BookCreateForm: React.FC<BookCreateFormProps> = ({ form }) => {
     return <Loader />;
   }
 
+  const exactAuthorMatch = data.authors.some((a) => a.name === authorSearch);
+
+  const handleAuthorSelect = (val: string) => {
+    setAuthorSearch("");
+    if (val === "$create") {
+      const name = authorSearch;
+      form.setFieldValue("authors", [
+        ...form.values.authors,
+        { id: `__pending__:${name}`, name },
+      ]);
+    } else {
+      const already = form.values.authors.some((a) => a.id === val);
+      if (already) {
+        form.setFieldValue(
+          "authors",
+          form.values.authors.filter((a) => a.id !== val),
+        );
+      } else {
+        const author = data.authors.find((a) => a.id === val);
+        if (author) {
+          form.setFieldValue("authors", [...form.values.authors, author]);
+        }
+      }
+    }
+  };
+
+  const handleAuthorRemove = (id: string) => {
+    form.setFieldValue(
+      "authors",
+      form.values.authors.filter((a) => a.id !== id),
+    );
+  };
+
   return (
     <Stack>
       <TextInput label="書名" {...form.getInputProps("title")} />
-      <MultiSelect
-        label="著者"
-        data={data.authors.map((author) => ({
-          value: author.id,
-          label: author.name,
-        }))}
-        searchable
-        {...form.getInputProps("authors")}
-        value={form.values.authors.map((author) => author.id)}
-        onChange={(authorIds) => {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-          form.getInputProps("authors").onChange(
-            authorIds.map((authorId) => ({
-              id: authorId,
-              name: data.authors.find((author) => author.id === authorId)?.name,
-            })),
-          );
-        }}
-      />
+      <Combobox store={combobox} onOptionSubmit={handleAuthorSelect}>
+        <Combobox.DropdownTarget>
+          <PillsInput
+            label="著者"
+            onClick={() => {
+              combobox.openDropdown();
+            }}
+            error={
+              typeof form.errors.authors === "string"
+                ? form.errors.authors
+                : undefined
+            }
+          >
+            <Pill.Group>
+              {form.values.authors.map((author) => (
+                <Pill
+                  key={author.id}
+                  withRemoveButton
+                  onRemove={() => {
+                    handleAuthorRemove(author.id);
+                  }}
+                >
+                  {author.name}
+                </Pill>
+              ))}
+              <Combobox.EventsTarget>
+                <PillsInput.Field
+                  onFocus={() => {
+                    combobox.openDropdown();
+                  }}
+                  onBlur={() => {
+                    combobox.closeDropdown();
+                  }}
+                  value={authorSearch}
+                  placeholder="著者を検索"
+                  onChange={(e) => {
+                    combobox.updateSelectedOptionIndex();
+                    setAuthorSearch(e.currentTarget.value);
+                  }}
+                  onKeyDown={(e) => {
+                    if (
+                      e.key === "Backspace" &&
+                      authorSearch.length === 0 &&
+                      form.values.authors.length > 0
+                    ) {
+                      e.preventDefault();
+                      handleAuthorRemove(
+                        form.values.authors[form.values.authors.length - 1].id,
+                      );
+                    }
+                  }}
+                />
+              </Combobox.EventsTarget>
+            </Pill.Group>
+          </PillsInput>
+        </Combobox.DropdownTarget>
+
+        <Combobox.Dropdown>
+          <Combobox.Options>
+            {data.authors
+              .filter((a) =>
+                a.name
+                  .toLowerCase()
+                  .includes(authorSearch.trim().toLowerCase()),
+              )
+              .map((author) => (
+                <Combobox.Option
+                  value={author.id}
+                  key={author.id}
+                  active={form.values.authors.some((a) => a.id === author.id)}
+                >
+                  <Group gap="sm">
+                    {form.values.authors.some((a) => a.id === author.id) && (
+                      <CheckIcon size={12} />
+                    )}
+                    <span>{author.name}</span>
+                  </Group>
+                </Combobox.Option>
+              ))}
+
+            {!exactAuthorMatch && authorSearch.trim().length > 0 && (
+              <Combobox.Option value="$create">
+                + Create {authorSearch}
+              </Combobox.Option>
+            )}
+          </Combobox.Options>
+        </Combobox.Dropdown>
+      </Combobox>
       <Select
         label="形式"
         {...form.getInputProps("format")}

--- a/src/features/books/BookCreateForm.tsx
+++ b/src/features/books/BookCreateForm.tsx
@@ -72,12 +72,20 @@ export const BookCreateForm: React.FC<BookCreateFormProps> = ({ form }) => {
     return <Loader />;
   }
 
-  const exactAuthorMatch = data.authors.some((a) => a.name === authorSearch);
+  const normalizedSearch = authorSearch.trim().toLowerCase();
+  const exactAuthorMatch =
+    normalizedSearch.length > 0 &&
+    (data.authors.some((a) => a.name.toLowerCase() === normalizedSearch) ||
+      form.values.authors.some(
+        (a) =>
+          a.id.startsWith("__pending__:") &&
+          a.name.toLowerCase() === normalizedSearch,
+      ));
 
   const handleAuthorSelect = (val: string) => {
     setAuthorSearch("");
     if (val === "$create") {
-      const name = authorSearch;
+      const name = authorSearch.trim();
       form.setFieldValue("authors", [
         ...form.values.authors,
         { id: `__pending__:${name}`, name },

--- a/src/features/books/BookCreateForm.tsx
+++ b/src/features/books/BookCreateForm.tsx
@@ -1,23 +1,19 @@
 import {
   ActionIcon,
   Checkbox,
-  CheckIcon,
-  Combobox,
   Group,
   Loader,
   NumberInput,
-  Pill,
-  PillsInput,
   Select,
   Stack,
   Text,
   TextInput,
-  useCombobox,
 } from "@mantine/core";
 import { UseFormReturnType } from "@mantine/form";
 import { IconSearch } from "@tabler/icons-react";
-import React, { useState } from "react";
+import React from "react";
 import { useAuthors } from "../../compoments/hooks/useAuthors";
+import { AuthorsCombobox } from "./AuthorsCombobox";
 import { BookFormValues } from "./bookFormSchema";
 import { Author } from "./entity/Author";
 import { BOOK_FORMAT_VALUE, displayBookFormat } from "./entity/BookFormat";
@@ -31,16 +27,6 @@ type BookCreateFormProps = {
 export const BookCreateForm: React.FC<BookCreateFormProps> = ({ form }) => {
   const { data, isLoading, error } = useAuthors();
   const { state: isbnLookupState, lookup: lookupIsbn } = useIsbnLookup();
-  const [authorSearch, setAuthorSearch] = useState("");
-
-  const combobox = useCombobox({
-    onDropdownClose: () => {
-      combobox.resetSelectedOption();
-    },
-    onDropdownOpen: () => {
-      combobox.updateSelectedOptionIndex("active");
-    },
-  });
 
   const handleIsbnLookup = async () => {
     const result = await lookupIsbn(form.values.isbn);
@@ -72,138 +58,21 @@ export const BookCreateForm: React.FC<BookCreateFormProps> = ({ form }) => {
     return <Loader />;
   }
 
-  const normalizedSearch = authorSearch.trim().toLowerCase();
-  const exactAuthorMatch =
-    normalizedSearch.length > 0 &&
-    (data.authors.some((a) => a.name.toLowerCase() === normalizedSearch) ||
-      form.values.authors.some(
-        (a) =>
-          a.id.startsWith("__pending__:") &&
-          a.name.toLowerCase() === normalizedSearch,
-      ));
-
-  const handleAuthorSelect = (val: string) => {
-    setAuthorSearch("");
-    if (val === "$create") {
-      const name = authorSearch.trim();
-      form.setFieldValue("authors", [
-        ...form.values.authors,
-        { id: `__pending__:${name}`, name },
-      ]);
-    } else {
-      const already = form.values.authors.some((a) => a.id === val);
-      if (already) {
-        form.setFieldValue(
-          "authors",
-          form.values.authors.filter((a) => a.id !== val),
-        );
-      } else {
-        const author = data.authors.find((a) => a.id === val);
-        if (author) {
-          form.setFieldValue("authors", [...form.values.authors, author]);
-        }
-      }
-    }
-  };
-
-  const handleAuthorRemove = (id: string) => {
-    form.setFieldValue(
-      "authors",
-      form.values.authors.filter((a) => a.id !== id),
-    );
-  };
-
   return (
     <Stack>
       <TextInput label="書名" {...form.getInputProps("title")} />
-      <Combobox store={combobox} onOptionSubmit={handleAuthorSelect}>
-        <Combobox.DropdownTarget>
-          <PillsInput
-            label="著者"
-            onClick={() => {
-              combobox.openDropdown();
-            }}
-            error={
-              typeof form.errors.authors === "string"
-                ? form.errors.authors
-                : undefined
-            }
-          >
-            <Pill.Group>
-              {form.values.authors.map((author) => (
-                <Pill
-                  key={author.id}
-                  withRemoveButton
-                  onRemove={() => {
-                    handleAuthorRemove(author.id);
-                  }}
-                >
-                  {author.name}
-                </Pill>
-              ))}
-              <Combobox.EventsTarget>
-                <PillsInput.Field
-                  onFocus={() => {
-                    combobox.openDropdown();
-                  }}
-                  onBlur={() => {
-                    combobox.closeDropdown();
-                  }}
-                  value={authorSearch}
-                  placeholder="著者を検索"
-                  onChange={(e) => {
-                    combobox.updateSelectedOptionIndex();
-                    setAuthorSearch(e.currentTarget.value);
-                  }}
-                  onKeyDown={(e) => {
-                    if (
-                      e.key === "Backspace" &&
-                      authorSearch.length === 0 &&
-                      form.values.authors.length > 0
-                    ) {
-                      e.preventDefault();
-                      handleAuthorRemove(
-                        form.values.authors[form.values.authors.length - 1].id,
-                      );
-                    }
-                  }}
-                />
-              </Combobox.EventsTarget>
-            </Pill.Group>
-          </PillsInput>
-        </Combobox.DropdownTarget>
-
-        <Combobox.Dropdown>
-          <Combobox.Options>
-            {data.authors
-              .filter((a) =>
-                a.name
-                  .toLowerCase()
-                  .includes(authorSearch.trim().toLowerCase()),
-              )
-              .map((author) => (
-                <Combobox.Option
-                  value={author.id}
-                  key={author.id}
-                  active={form.values.authors.some((a) => a.id === author.id)}
-                >
-                  <Group gap="sm">
-                    {form.values.authors.some((a) => a.id === author.id) && (
-                      <CheckIcon size={12} />
-                    )}
-                    <span>{author.name}</span>
-                  </Group>
-                </Combobox.Option>
-              ))}
-
-            {!exactAuthorMatch && authorSearch.trim().length > 0 && (
-              <Combobox.Option value="$create">
-                + Create {authorSearch}
-              </Combobox.Option>
-            )}
-          </Combobox.Options>
-        </Combobox.Dropdown>
-      </Combobox>
+      <AuthorsCombobox
+        authors={data.authors}
+        value={form.values.authors}
+        onChange={(v) => {
+          form.setFieldValue("authors", v);
+        }}
+        error={
+          typeof form.errors.authors === "string"
+            ? form.errors.authors
+            : undefined
+        }
+      />
       <Select
         label="形式"
         {...form.getInputProps("format")}

--- a/src/features/books/BookDetailEdit.tsx
+++ b/src/features/books/BookDetailEdit.tsx
@@ -21,13 +21,25 @@ export const BookDetailEdit: React.FC<{ book: Book }> = (props) => {
   const createAuthorMutation = useCreateAuthor();
 
   const handleSubmit = async (values: BookFormValues) => {
-    const resolvedAuthors = await resolvePendingAuthors(
-      values.authors,
-      async (name) => {
-        const result = await createAuthorMutation.mutateAsync({ name });
-        return result.createAuthor.id;
-      },
-    );
+    let resolvedAuthors: Awaited<ReturnType<typeof resolvePendingAuthors>>;
+    try {
+      resolvedAuthors = await resolvePendingAuthors(
+        values.authors,
+        async (name) => {
+          const result = await createAuthorMutation.mutateAsync({ name });
+          return result.createAuthor.id;
+        },
+      );
+    } catch (error) {
+      showNotification({
+        message: `Failed to create author: ${String(error)}`,
+        color: "red",
+      });
+      return;
+    }
+
+    form.setFieldValue("authors", resolvedAuthors);
+
     const bookData = {
       id: book.id,
       title: values.title,
@@ -39,9 +51,17 @@ export const BookDetailEdit: React.FC<{ book: Book }> = (props) => {
       store: values.store,
       authorIds: resolvedAuthors.map((a) => a.id),
     };
-    await updateBookMutation.mutateAsync(bookData);
-    await navigate({ to: `/books/$id`, params: { id: book.id } });
-    showNotification({ message: "更新しました", color: "teal" });
+
+    try {
+      await updateBookMutation.mutateAsync(bookData);
+      await navigate({ to: `/books/$id`, params: { id: book.id } });
+      showNotification({ message: "更新しました", color: "teal" });
+    } catch (error) {
+      showNotification({
+        message: `Failed to update book: ${String(error)}`,
+        color: "red",
+      });
+    }
   };
 
   const form = useForm<BookFormValues>({

--- a/src/features/books/BookDetailEdit.tsx
+++ b/src/features/books/BookDetailEdit.tsx
@@ -5,8 +5,10 @@ import { useNavigate } from "@tanstack/react-router";
 import { zodResolver } from "mantine-form-zod-resolver";
 import React from "react";
 import { LinkButton } from "../../compoments/mantineTsr";
+import { useCreateAuthor } from "../../compoments/hooks/useCreateAuthor";
 import { useUpdateBook } from "../../compoments/hooks/useUpdateBook";
 import { bookFormSchema, BookFormValues } from "./bookFormSchema";
+import { resolvePendingAuthors } from "./resolvePendingAuthors";
 import { BookUpdateForm } from "./BookUpdateForm";
 import { Book } from "./entity/Book";
 
@@ -16,8 +18,16 @@ export const BookDetailEdit: React.FC<{ book: Book }> = (props) => {
   const navigate = useNavigate();
 
   const updateBookMutation = useUpdateBook();
+  const createAuthorMutation = useCreateAuthor();
 
   const handleSubmit = async (values: BookFormValues) => {
+    const resolvedAuthors = await resolvePendingAuthors(
+      values.authors,
+      async (name) => {
+        const result = await createAuthorMutation.mutateAsync({ name });
+        return result.createAuthor.id;
+      },
+    );
     const bookData = {
       id: book.id,
       title: values.title,
@@ -27,7 +37,7 @@ export const BookDetailEdit: React.FC<{ book: Book }> = (props) => {
       priority: values.priority,
       format: values.format,
       store: values.store,
-      authorIds: values.authors.map((author) => author.id),
+      authorIds: resolvedAuthors.map((a) => a.id),
     };
     await updateBookMutation.mutateAsync(bookData);
     await navigate({ to: `/books/$id`, params: { id: book.id } });

--- a/src/features/books/BookUpdateForm.tsx
+++ b/src/features/books/BookUpdateForm.tsx
@@ -1,14 +1,19 @@
 import {
   Checkbox,
+  CheckIcon,
+  Combobox,
+  Group,
   Loader,
-  MultiSelect,
   NumberInput,
+  Pill,
+  PillsInput,
   Select,
   Stack,
   TextInput,
+  useCombobox,
 } from "@mantine/core";
 import { UseFormReturnType } from "@mantine/form";
-import React from "react";
+import React, { useState } from "react";
 import { useAuthors } from "../../compoments/hooks/useAuthors";
 import { BookFormValues } from "./bookFormSchema";
 import { BOOK_FORMAT_VALUE, displayBookFormat } from "./entity/BookFormat";
@@ -20,6 +25,16 @@ type BookUpdateFormProps = {
 
 export const BookUpdateForm: React.FC<BookUpdateFormProps> = ({ form }) => {
   const { data, isLoading, error } = useAuthors();
+  const [authorSearch, setAuthorSearch] = useState("");
+
+  const combobox = useCombobox({
+    onDropdownClose: () => {
+      combobox.resetSelectedOption();
+    },
+    onDropdownOpen: () => {
+      combobox.updateSelectedOptionIndex("active");
+    },
+  });
 
   if (error) {
     return <div>{JSON.stringify(error)}</div>;
@@ -29,28 +44,130 @@ export const BookUpdateForm: React.FC<BookUpdateFormProps> = ({ form }) => {
     return <Loader />;
   }
 
+  const exactAuthorMatch = data.authors.some((a) => a.name === authorSearch);
+
+  const handleAuthorSelect = (val: string) => {
+    setAuthorSearch("");
+    if (val === "$create") {
+      const name = authorSearch;
+      form.setFieldValue("authors", [
+        ...form.values.authors,
+        { id: `__pending__:${name}`, name },
+      ]);
+    } else {
+      const already = form.values.authors.some((a) => a.id === val);
+      if (already) {
+        form.setFieldValue(
+          "authors",
+          form.values.authors.filter((a) => a.id !== val),
+        );
+      } else {
+        const author = data.authors.find((a) => a.id === val);
+        if (author) {
+          form.setFieldValue("authors", [...form.values.authors, author]);
+        }
+      }
+    }
+  };
+
+  const handleAuthorRemove = (id: string) => {
+    form.setFieldValue(
+      "authors",
+      form.values.authors.filter((a) => a.id !== id),
+    );
+  };
+
   return (
     <Stack>
       <TextInput label="書名" {...form.getInputProps("title")} />
-      <MultiSelect
-        label="著者"
-        data={data.authors.map((author) => ({
-          value: author.id,
-          label: author.name,
-        }))}
-        searchable
-        {...form.getInputProps("authors")}
-        value={form.values.authors.map((author) => author.id)}
-        onChange={(authorIds) => {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-          form.getInputProps("authors").onChange(
-            authorIds.map((authorId) => ({
-              id: authorId,
-              name: data.authors.find((author) => author.id === authorId)?.name,
-            })),
-          );
-        }}
-      />
+      <Combobox store={combobox} onOptionSubmit={handleAuthorSelect}>
+        <Combobox.DropdownTarget>
+          <PillsInput
+            label="著者"
+            onClick={() => {
+              combobox.openDropdown();
+            }}
+            error={
+              typeof form.errors.authors === "string"
+                ? form.errors.authors
+                : undefined
+            }
+          >
+            <Pill.Group>
+              {form.values.authors.map((author) => (
+                <Pill
+                  key={author.id}
+                  withRemoveButton
+                  onRemove={() => {
+                    handleAuthorRemove(author.id);
+                  }}
+                >
+                  {author.name}
+                </Pill>
+              ))}
+              <Combobox.EventsTarget>
+                <PillsInput.Field
+                  onFocus={() => {
+                    combobox.openDropdown();
+                  }}
+                  onBlur={() => {
+                    combobox.closeDropdown();
+                  }}
+                  value={authorSearch}
+                  placeholder="著者を検索"
+                  onChange={(e) => {
+                    combobox.updateSelectedOptionIndex();
+                    setAuthorSearch(e.currentTarget.value);
+                  }}
+                  onKeyDown={(e) => {
+                    if (
+                      e.key === "Backspace" &&
+                      authorSearch.length === 0 &&
+                      form.values.authors.length > 0
+                    ) {
+                      e.preventDefault();
+                      handleAuthorRemove(
+                        form.values.authors[form.values.authors.length - 1].id,
+                      );
+                    }
+                  }}
+                />
+              </Combobox.EventsTarget>
+            </Pill.Group>
+          </PillsInput>
+        </Combobox.DropdownTarget>
+
+        <Combobox.Dropdown>
+          <Combobox.Options>
+            {data.authors
+              .filter((a) =>
+                a.name
+                  .toLowerCase()
+                  .includes(authorSearch.trim().toLowerCase()),
+              )
+              .map((author) => (
+                <Combobox.Option
+                  value={author.id}
+                  key={author.id}
+                  active={form.values.authors.some((a) => a.id === author.id)}
+                >
+                  <Group gap="sm">
+                    {form.values.authors.some((a) => a.id === author.id) && (
+                      <CheckIcon size={12} />
+                    )}
+                    <span>{author.name}</span>
+                  </Group>
+                </Combobox.Option>
+              ))}
+
+            {!exactAuthorMatch && authorSearch.trim().length > 0 && (
+              <Combobox.Option value="$create">
+                + Create {authorSearch}
+              </Combobox.Option>
+            )}
+          </Combobox.Options>
+        </Combobox.Dropdown>
+      </Combobox>
       <Select
         label="形式"
         {...form.getInputProps("format")}

--- a/src/features/books/BookUpdateForm.tsx
+++ b/src/features/books/BookUpdateForm.tsx
@@ -44,12 +44,20 @@ export const BookUpdateForm: React.FC<BookUpdateFormProps> = ({ form }) => {
     return <Loader />;
   }
 
-  const exactAuthorMatch = data.authors.some((a) => a.name === authorSearch);
+  const normalizedSearch = authorSearch.trim().toLowerCase();
+  const exactAuthorMatch =
+    normalizedSearch.length > 0 &&
+    (data.authors.some((a) => a.name.toLowerCase() === normalizedSearch) ||
+      form.values.authors.some(
+        (a) =>
+          a.id.startsWith("__pending__:") &&
+          a.name.toLowerCase() === normalizedSearch,
+      ));
 
   const handleAuthorSelect = (val: string) => {
     setAuthorSearch("");
     if (val === "$create") {
-      const name = authorSearch;
+      const name = authorSearch.trim();
       form.setFieldValue("authors", [
         ...form.values.authors,
         { id: `__pending__:${name}`, name },

--- a/src/features/books/BookUpdateForm.tsx
+++ b/src/features/books/BookUpdateForm.tsx
@@ -1,20 +1,15 @@
 import {
   Checkbox,
-  CheckIcon,
-  Combobox,
-  Group,
   Loader,
   NumberInput,
-  Pill,
-  PillsInput,
   Select,
   Stack,
   TextInput,
-  useCombobox,
 } from "@mantine/core";
 import { UseFormReturnType } from "@mantine/form";
-import React, { useState } from "react";
+import React from "react";
 import { useAuthors } from "../../compoments/hooks/useAuthors";
+import { AuthorsCombobox } from "./AuthorsCombobox";
 import { BookFormValues } from "./bookFormSchema";
 import { BOOK_FORMAT_VALUE, displayBookFormat } from "./entity/BookFormat";
 import { BOOK_STORE_VALUE, displayBookStore } from "./entity/BookStore";
@@ -25,16 +20,6 @@ type BookUpdateFormProps = {
 
 export const BookUpdateForm: React.FC<BookUpdateFormProps> = ({ form }) => {
   const { data, isLoading, error } = useAuthors();
-  const [authorSearch, setAuthorSearch] = useState("");
-
-  const combobox = useCombobox({
-    onDropdownClose: () => {
-      combobox.resetSelectedOption();
-    },
-    onDropdownOpen: () => {
-      combobox.updateSelectedOptionIndex("active");
-    },
-  });
 
   if (error) {
     return <div>{JSON.stringify(error)}</div>;
@@ -44,138 +29,21 @@ export const BookUpdateForm: React.FC<BookUpdateFormProps> = ({ form }) => {
     return <Loader />;
   }
 
-  const normalizedSearch = authorSearch.trim().toLowerCase();
-  const exactAuthorMatch =
-    normalizedSearch.length > 0 &&
-    (data.authors.some((a) => a.name.toLowerCase() === normalizedSearch) ||
-      form.values.authors.some(
-        (a) =>
-          a.id.startsWith("__pending__:") &&
-          a.name.toLowerCase() === normalizedSearch,
-      ));
-
-  const handleAuthorSelect = (val: string) => {
-    setAuthorSearch("");
-    if (val === "$create") {
-      const name = authorSearch.trim();
-      form.setFieldValue("authors", [
-        ...form.values.authors,
-        { id: `__pending__:${name}`, name },
-      ]);
-    } else {
-      const already = form.values.authors.some((a) => a.id === val);
-      if (already) {
-        form.setFieldValue(
-          "authors",
-          form.values.authors.filter((a) => a.id !== val),
-        );
-      } else {
-        const author = data.authors.find((a) => a.id === val);
-        if (author) {
-          form.setFieldValue("authors", [...form.values.authors, author]);
-        }
-      }
-    }
-  };
-
-  const handleAuthorRemove = (id: string) => {
-    form.setFieldValue(
-      "authors",
-      form.values.authors.filter((a) => a.id !== id),
-    );
-  };
-
   return (
     <Stack>
       <TextInput label="書名" {...form.getInputProps("title")} />
-      <Combobox store={combobox} onOptionSubmit={handleAuthorSelect}>
-        <Combobox.DropdownTarget>
-          <PillsInput
-            label="著者"
-            onClick={() => {
-              combobox.openDropdown();
-            }}
-            error={
-              typeof form.errors.authors === "string"
-                ? form.errors.authors
-                : undefined
-            }
-          >
-            <Pill.Group>
-              {form.values.authors.map((author) => (
-                <Pill
-                  key={author.id}
-                  withRemoveButton
-                  onRemove={() => {
-                    handleAuthorRemove(author.id);
-                  }}
-                >
-                  {author.name}
-                </Pill>
-              ))}
-              <Combobox.EventsTarget>
-                <PillsInput.Field
-                  onFocus={() => {
-                    combobox.openDropdown();
-                  }}
-                  onBlur={() => {
-                    combobox.closeDropdown();
-                  }}
-                  value={authorSearch}
-                  placeholder="著者を検索"
-                  onChange={(e) => {
-                    combobox.updateSelectedOptionIndex();
-                    setAuthorSearch(e.currentTarget.value);
-                  }}
-                  onKeyDown={(e) => {
-                    if (
-                      e.key === "Backspace" &&
-                      authorSearch.length === 0 &&
-                      form.values.authors.length > 0
-                    ) {
-                      e.preventDefault();
-                      handleAuthorRemove(
-                        form.values.authors[form.values.authors.length - 1].id,
-                      );
-                    }
-                  }}
-                />
-              </Combobox.EventsTarget>
-            </Pill.Group>
-          </PillsInput>
-        </Combobox.DropdownTarget>
-
-        <Combobox.Dropdown>
-          <Combobox.Options>
-            {data.authors
-              .filter((a) =>
-                a.name
-                  .toLowerCase()
-                  .includes(authorSearch.trim().toLowerCase()),
-              )
-              .map((author) => (
-                <Combobox.Option
-                  value={author.id}
-                  key={author.id}
-                  active={form.values.authors.some((a) => a.id === author.id)}
-                >
-                  <Group gap="sm">
-                    {form.values.authors.some((a) => a.id === author.id) && (
-                      <CheckIcon size={12} />
-                    )}
-                    <span>{author.name}</span>
-                  </Group>
-                </Combobox.Option>
-              ))}
-
-            {!exactAuthorMatch && authorSearch.trim().length > 0 && (
-              <Combobox.Option value="$create">
-                + Create {authorSearch}
-              </Combobox.Option>
-            )}
-          </Combobox.Options>
-        </Combobox.Dropdown>
-      </Combobox>
+      <AuthorsCombobox
+        authors={data.authors}
+        value={form.values.authors}
+        onChange={(v) => {
+          form.setFieldValue("authors", v);
+        }}
+        error={
+          typeof form.errors.authors === "string"
+            ? form.errors.authors
+            : undefined
+        }
+      />
       <Select
         label="形式"
         {...form.getInputProps("format")}

--- a/src/features/books/resolvePendingAuthors.test.ts
+++ b/src/features/books/resolvePendingAuthors.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test, vi } from "vitest";
+import { resolvePendingAuthors } from "./resolvePendingAuthors";
+
+describe("resolvePendingAuthors", () => {
+  test("returns non-pending authors unchanged", async () => {
+    const createAuthor = vi.fn();
+    const authors = [
+      { id: "1", name: "Alice" },
+      { id: "2", name: "Bob" },
+    ];
+
+    const result = await resolvePendingAuthors(authors, createAuthor);
+
+    expect(result).toEqual(authors);
+    expect(createAuthor).not.toHaveBeenCalled();
+  });
+
+  test("resolves a pending author via createAuthor", async () => {
+    const createAuthor = vi.fn().mockResolvedValue("new-id-1");
+    const authors = [{ id: "__pending__:Alice", name: "Alice" }];
+
+    const result = await resolvePendingAuthors(authors, createAuthor);
+
+    expect(createAuthor).toHaveBeenCalledWith("Alice");
+    expect(result).toEqual([{ id: "new-id-1", name: "Alice" }]);
+  });
+
+  test("deduplicates pending authors with the same name", async () => {
+    const createAuthor = vi.fn().mockResolvedValue("new-id-1");
+    const authors = [
+      { id: "__pending__:Alice", name: "Alice" },
+      { id: "__pending__:Alice", name: "Alice" },
+    ];
+
+    const result = await resolvePendingAuthors(authors, createAuthor);
+
+    expect(createAuthor).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      { id: "new-id-1", name: "Alice" },
+      { id: "new-id-1", name: "Alice" },
+    ]);
+  });
+
+  test("resolves mixed real and pending authors", async () => {
+    const createAuthor = vi.fn().mockResolvedValue("new-id-2");
+    const authors = [
+      { id: "1", name: "Bob" },
+      { id: "__pending__:Alice", name: "Alice" },
+    ];
+
+    const result = await resolvePendingAuthors(authors, createAuthor);
+
+    expect(createAuthor).toHaveBeenCalledWith("Alice");
+    expect(result).toEqual([
+      { id: "1", name: "Bob" },
+      { id: "new-id-2", name: "Alice" },
+    ]);
+  });
+});

--- a/src/features/books/resolvePendingAuthors.ts
+++ b/src/features/books/resolvePendingAuthors.ts
@@ -1,0 +1,16 @@
+import type { Author } from "./entity/Author";
+
+export const resolvePendingAuthors = async (
+  authors: Author[],
+  createAuthor: (name: string) => Promise<string>,
+): Promise<Author[]> => {
+  return Promise.all(
+    authors.map(async (author) => {
+      if (author.id.startsWith("__pending__:")) {
+        const id = await createAuthor(author.name);
+        return { id, name: author.name };
+      }
+      return author;
+    }),
+  );
+};

--- a/src/features/books/resolvePendingAuthors.ts
+++ b/src/features/books/resolvePendingAuthors.ts
@@ -4,13 +4,23 @@ export const resolvePendingAuthors = async (
   authors: Author[],
   createAuthor: (name: string) => Promise<string>,
 ): Promise<Author[]> => {
-  return Promise.all(
-    authors.map(async (author) => {
-      if (author.id.startsWith("__pending__:")) {
-        const id = await createAuthor(author.name);
-        return { id, name: author.name };
-      }
-      return author;
+  const pendingNames = new Set(
+    authors.filter((a) => a.id.startsWith("__pending__:")).map((a) => a.name),
+  );
+
+  const nameToId = new Map<string, string>();
+  await Promise.all(
+    Array.from(pendingNames).map(async (name) => {
+      const id = await createAuthor(name);
+      nameToId.set(name, id);
     }),
   );
+
+  return authors.map((author) => {
+    if (author.id.startsWith("__pending__:")) {
+      const id = nameToId.get(author.name);
+      return { id: id ?? author.id, name: author.name };
+    }
+    return author;
+  });
 };


### PR DESCRIPTION
## Summary

- Replace `MultiSelect` author field in both `BookUpdateForm` and `BookCreateForm` with a Mantine `Combobox`-based creatable component
- Typing a name with no match shows a \"+ Create \<name\>\" option; selecting it marks the author as pending (`__pending__:<name>`) in form state
- Add `resolvePendingAuthors` utility that creates pending authors via GraphQL at submit time before saving the book
- Update `BookDetailEdit` and `BookAddButton` to resolve pending authors before calling their respective mutations

## Test plan

- [ ] Navigate to a book's edit page, type a new author name, select \"+ Create \<name\>\", press Save — book saves and new author appears in `/authors`
- [ ] Open the book-add modal, type a new author name, select \"+ Create \<name\>\", fill title and press 追加 — book created and new author exists
- [ ] Type an existing author name — confirm \"+ Create\" option does NOT appear
- [ ] `npm run test` — all 42 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 書籍フォームの著者フィールドを改善。既存著者を選択するか、新規著者を直接入力・作成できるようになりました。
  * フォーム保存時に未確定の著者エントリを自動的に解決するロジックを追加。

* **テスト**
  * 新しい著者フィールド機能のテストスイートを追加。

* **ドキュメント**
  * テスティングポリシーセクションを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Reference

- https://mantine.dev/combobox/?e=MultiSelectCreatable