### PR TITLE
Fix release-drafter PR creation permission

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,7 +12,7 @@ jobs:
   update_release_draft:
     permissions:
       contents: write
-      pull-requests: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- Change `pull-requests` permission from `read` to `write` in release-drafter workflow
- Required for `peter-evans/create-pull-request` to create PRs via `GITHUB_TOKEN`

## Root cause
The job had `pull-requests: read`, which caused the "Resource not accessible by integration" error when attempting to create a pull request.