### PR TITLE
Add check-generated CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,20 @@ jobs:
       - run: npm run lint
       - run: npm run build
 
+  check-generated:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "24"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run generate
+      - run: git diff --exit-code
+
   test-e2e-mock-api:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Add `check-generated` CI job that runs `npm run generate` and verifies no diff is produced
- Ensures generated files (GraphQL types, MSW worker, route tree) are always committed and up to date

## Test plan

- [ ] Confirm the CI job passes on this PR
- [ ] Verify the job fails if generated files are out of date

🤖 Generated with [Claude Code](https://claude.com/claude-code)