### PR TITLE
Enable no-unsafe-type-assertion ESLint rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,6 @@
 - When ignoring a linter or security tool finding, always add a comment
   explaining why it is safe to ignore. Place the comment on the line immediately
   before the ignore directive.
-- **Do not use `as` type assertions** (e.g. `foo as SomeType`). Use proper
-  type narrowing or type guards instead. `as const` is allowed.
 
 ## Branching (REQUIRED FIRST STEP)
 

--- a/e2e-mock-api/fixtures.ts
+++ b/e2e-mock-api/fixtures.ts
@@ -193,7 +193,7 @@ window.parent.postMessage({
       try {
         const graphqlRequestSchema = z.object({
           query: z.string(),
-          variables: z.record(z.string(), z.unknown()).nullish(),
+          variables: z.record(z.string(), z.unknown()).optional(),
         });
         const body = graphqlRequestSchema.parse(route.request().postDataJSON());
         log("GraphQL query:", body.query.substring(0, 50));

--- a/e2e-mock-api/fixtures.ts
+++ b/e2e-mock-api/fixtures.ts
@@ -193,7 +193,7 @@ window.parent.postMessage({
       try {
         const graphqlRequestSchema = z.object({
           query: z.string(),
-          variables: z.record(z.string(), z.unknown()),
+          variables: z.record(z.string(), z.unknown()).nullish(),
         });
         const body = graphqlRequestSchema.parse(route.request().postDataJSON());
         log("GraphQL query:", body.query.substring(0, 50));

--- a/e2e-mock-api/fixtures.ts
+++ b/e2e-mock-api/fixtures.ts
@@ -4,6 +4,7 @@ import { test as base } from "@playwright/test";
 import { readFileSync } from "fs";
 import { graphqlSync } from "graphql";
 import { importJWK, SignJWT } from "jose";
+import { z } from "zod";
 import type { MockStore } from "./mockStore";
 import { createResolvers } from "./resolvers";
 import { TEST_AUTH0_CLIENT_ID, TEST_AUTH0_DOMAIN } from "./testConstants";
@@ -190,10 +191,11 @@ window.parent.postMessage({
     await page.route("http://localhost:4000/graphql", async (route) => {
       log("GraphQL route hit");
       try {
-        const body = route.request().postDataJSON() as {
-          query: string;
-          variables: Record<string, unknown>;
-        };
+        const graphqlRequestSchema = z.object({
+          query: z.string(),
+          variables: z.record(z.string(), z.unknown()),
+        });
+        const body = graphqlRequestSchema.parse(route.request().postDataJSON());
         log("GraphQL query:", body.query.substring(0, 50));
         const { query, variables } = body;
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -109,6 +109,7 @@ export default tseslint.config(
       // This project does not use React Compiler, so disable the compiler
       // compatibility warning for third-party libraries (e.g. TanStack Table).
       "react-hooks/incompatible-library": "off",
+      "@typescript-eslint/no-unsafe-type-assertion": "error",
       "@typescript-eslint/consistent-type-definitions": ["warn", "type"],
       "no-plusplus": [
         "error",

--- a/src/features/books/AuthorsFilter.tsx
+++ b/src/features/books/AuthorsFilter.tsx
@@ -10,6 +10,10 @@ export const AuthorsFilter = <TData, TValue>({
   column,
 }: AuthorsFilterProps<TData, TValue>): React.JSX.Element => {
   const { data, isLoading, error } = useAuthors();
+  const filterValue = column.getFilterValue();
+  const selectedIds = Array.isArray(filterValue)
+    ? filterValue.filter((x): x is string => typeof x === "string")
+    : [];
 
   if (error) {
     console.error("AuthorsFilter: failed to load authors", error);
@@ -25,7 +29,7 @@ export const AuthorsFilter = <TData, TValue>({
         })) ?? []
       }
       searchable
-      value={(column.getFilterValue() ?? []) as string[]}
+      value={selectedIds}
       onChange={(authorIds) => {
         column.setFilterValue(authorIds);
       }}

--- a/src/features/books/BookList.tsx
+++ b/src/features/books/BookList.tsx
@@ -37,10 +37,10 @@ import {
   IconSortDescending,
 } from "@tabler/icons-react";
 import { getRouteApi } from "@tanstack/react-router";
-import React, { ReactNode, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "../../compoments/mantineTsr";
 import { ShowBoolean } from "../../compoments/utils/ShowBoolean";
-import { Author } from "./entity/Author";
+import { authorSchema } from "./entity/Author";
 import { Book } from "./entity/Book";
 import { displayBookFormat } from "./entity/BookFormat";
 import { displayBookStore } from "./entity/BookStore";
@@ -65,9 +65,12 @@ const authorsFilter: FilterFn<Book> = (
     return true;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-  const value = row.getValue(columnId) as Author[];
-  return value.some((author) => filterValue.includes(author.id));
+  const value = row.getValue(columnId);
+  if (!Array.isArray(value)) return false;
+  return value.some((item) => {
+    const parsed = authorSchema.safeParse(item);
+    return parsed.success && filterValue.includes(parsed.data.id);
+  });
 };
 
 const formatDate = (date: Date) => dayjs(date).format("YYYY/MM/DD HH:mm Z");
@@ -76,7 +79,7 @@ const DEFAULT_PAGE_SIZE = 20;
 
 const columnHelper = createColumnHelper<Book>();
 
-const columns = [
+const columns: ColumnDef<Book>[] = [
   columnHelper.accessor("title", {
     header: "書名",
     cell: (info) => (
@@ -145,7 +148,7 @@ const columns = [
       <Box style={{ whiteSpace: "nowrap" }}>{formatDate(info.getValue())}</Box>
     ),
   }),
-] as ColumnDef<Book>[];
+];
 
 type BookListProps = { list: Book[] };
 
@@ -181,12 +184,10 @@ export const BookList: React.FC<BookListProps> = ({ list }) => {
   const navigate = routeApi.useNavigate();
   const search = routeApi.useSearch();
 
-  const [columnFilters, setColumnFilters] = useState(
-    (search.columnFilters ?? []) as ColumnFiltersState,
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(
+    search.columnFilters ?? [],
   );
-  const [sorting, setSorting] = useState(
-    (search.sorting ?? []) as SortingState,
-  );
+  const [sorting, setSorting] = useState<SortingState>(search.sorting ?? []);
   const [pagination, setPagination] = useState({
     pageIndex: search.pageIndex ?? 0,
     pageSize: search.pageSize ?? DEFAULT_PAGE_SIZE,
@@ -196,13 +197,13 @@ export const BookList: React.FC<BookListProps> = ({ list }) => {
   const serializedSorting = JSON.stringify(search.sorting ?? []);
 
   useEffect(() => {
-    setColumnFilters((search.columnFilters ?? []) as ColumnFiltersState);
+    setColumnFilters(search.columnFilters ?? []);
     // serializedColumnFilters is the stable dep; search.columnFilters is the current value.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [serializedColumnFilters]);
 
   useEffect(() => {
-    setSorting((search.sorting ?? []) as SortingState);
+    setSorting(search.sorting ?? []);
     // serializedSorting is the stable dep; search.sorting is the current value.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [serializedSorting]);
@@ -291,7 +292,11 @@ export const BookList: React.FC<BookListProps> = ({ list }) => {
                 return (
                   <Checkbox
                     key={column.id}
-                    label={column.columnDef.header as ReactNode}
+                    label={
+                      typeof column.columnDef.header === "string"
+                        ? column.columnDef.header
+                        : undefined
+                    }
                     checked={column.getIsVisible()}
                     onChange={column.getToggleVisibilityHandler()}
                   />

--- a/src/features/books/BookList.tsx
+++ b/src/features/books/BookList.tsx
@@ -295,7 +295,7 @@ export const BookList: React.FC<BookListProps> = ({ list }) => {
                     label={
                       typeof column.columnDef.header === "string"
                         ? column.columnDef.header
-                        : undefined
+                        : column.id
                     }
                     checked={column.getIsVisible()}
                     onChange={column.getToggleVisibilityHandler()}

--- a/src/features/books/FormatFilter.tsx
+++ b/src/features/books/FormatFilter.tsx
@@ -9,6 +9,7 @@ export type FormatFilterProps<TData, TValue> = {
 export const FormatFilter = <TData, TValue>({
   column,
 }: FormatFilterProps<TData, TValue>): React.JSX.Element => {
+  const filterValue = column.getFilterValue();
   return (
     <Select
       data={[
@@ -18,7 +19,7 @@ export const FormatFilter = <TData, TValue>({
           label: displayBookFormat(format),
         })),
       ]}
-      value={(column.getFilterValue() as string | undefined) ?? ""}
+      value={typeof filterValue === "string" ? filterValue : ""}
       onChange={(value) => {
         column.setFilterValue(value);
       }}

--- a/src/features/books/StoreFilter.tsx
+++ b/src/features/books/StoreFilter.tsx
@@ -7,6 +7,7 @@ export type StoreFilterProps<TData, TValue> = { column: Column<TData, TValue> };
 export const StoreFilter = <TData, TValue>({
   column,
 }: StoreFilterProps<TData, TValue>): React.JSX.Element => {
+  const filterValue = column.getFilterValue();
   return (
     <Select
       data={[
@@ -16,7 +17,7 @@ export const StoreFilter = <TData, TValue>({
           label: displayBookStore(format),
         })),
       ]}
-      value={(column.getFilterValue() as string | undefined) ?? ""}
+      value={typeof filterValue === "string" ? filterValue : ""}
       onChange={(value) => {
         column.setFilterValue(value);
       }}

--- a/src/features/books/StringFilter.tsx
+++ b/src/features/books/StringFilter.tsx
@@ -10,7 +10,10 @@ export type StringFilterProps<TData, TValue> = {
 export const StringFilter = <TData, TValue>({
   column,
 }: StringFilterProps<TData, TValue>) => {
-  const [value, setValue] = useState((column.getFilterValue() ?? "") as string);
+  const initial = column.getFilterValue();
+  const [value, setValue] = useState(
+    typeof initial === "string" ? initial : "",
+  );
 
   useDebouncedEffect(
     () => {
@@ -27,7 +30,7 @@ export const StringFilter = <TData, TValue>({
     // filter resets (e.g. "clear all filters"). No infinite loop risk as
     // filterValue changes are externally driven. Expect improvement in v9.
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setValue((filterValue as string | undefined) ?? "");
+    setValue(typeof filterValue === "string" ? filterValue : "");
   }, [filterValue]);
 
   return (

--- a/src/features/books/entity/Author.ts
+++ b/src/features/books/entity/Author.ts
@@ -1,4 +1,8 @@
-export type Author = {
-  id: string;
-  name: string;
-};
+import { z } from "zod";
+
+export const authorSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+export type Author = z.infer<typeof authorSchema>;

--- a/src/routes/authors/index.tsx
+++ b/src/routes/authors/index.tsx
@@ -22,6 +22,7 @@ import { useState } from "react";
 import { useCreateAuthor } from "../../compoments/hooks/useCreateAuthor";
 import { useAuthors } from "../../compoments/hooks/useAuthors";
 import { Link } from "../../compoments/mantineTsr";
+import type { Author } from "../../features/books/entity/Author";
 
 export const Route = createFileRoute("/authors/")({
   component: RouteComponent,
@@ -30,11 +31,6 @@ export const Route = createFileRoute("/authors/")({
 function RouteComponent() {
   return <AuthorIndexPage />;
 }
-
-type Author = {
-  id: string;
-  name: string;
-};
 
 type RegisterAuthorFormInput = {
   name: string;

--- a/src/routes/authors/index.tsx
+++ b/src/routes/authors/index.tsx
@@ -69,7 +69,7 @@ const AuthorIndexPage: React.FC = () => {
   const { data, isLoading, error } = useAuthors();
   const [globalFilter, setGlobalFilter] = useState("");
   const columnHelper = createColumnHelper<Author>();
-  const columns = [
+  const columns: ColumnDef<Author>[] = [
     columnHelper.accessor("name", {
       header: "名前",
       cell: ({ row }) => (
@@ -78,7 +78,7 @@ const AuthorIndexPage: React.FC = () => {
         </Link>
       ),
     }),
-  ] as ColumnDef<Author>[];
+  ];
   const table = useReactTable({
     data: data?.authors ?? [], // その場しのぎ
     columns,


### PR DESCRIPTION
Replace all `as T` casts with type guards or Zod schemas:
- Add Zod schema to Author entity; use safeParse in
  authorsFilter to avoid casting row.getValue() result
- Fix getFilterValue() casts in FormatFilter, StoreFilter,
  StringFilter, and AuthorsFilter with typeof/Array.isArray
  guards
- Use explicit useState<T> type params instead of cast for
  ColumnFiltersState and SortingState in BookList
- Switch columns array to explicit annotation instead of `as`
  in BookList and authors route
- Narrow columnDef.header with typeof instead of ReactNode cast
- Fix e2e fixture postDataJSON() cast using Zod parse
- Remove AGENTS.md instruction now enforced by the lint rule

https://claude.ai/code/session_01HqZRGWCAJuS792ck2Lhv2v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * フィルター入力の型検証をランタイムで強化し、無効なデータ処理をより堅牢にしました。
  
* **Chores**
  * コードベースの型安全性を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->