### PR TITLE
Update GraphQL codegen packages

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -2,10 +2,18 @@ overwrite: true
 schema: "src/graphql/schema.graphql"
 documents: "src/**/*.graphql"
 generates:
-  src/generated/graphql-request.ts:
+  src/generated/graphql-schema.ts:
     config:
       enumsAsTypes: true
     plugins:
       - "typescript"
+  src/generated/graphql-request.ts:
+    config:
+      enumsAsTypes: true
+      importSchemaTypesFrom: 'src/generated/graphql-schema'
+      namespacedImportName: 'Types'
+    plugins:
+      - add:
+          content: "export * from './graphql-schema';"
       - "typescript-operations"
       - "typescript-graphql-request"

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,10 +33,10 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.12",
         "@eslint/js": "9.39.4",
-        "@graphql-codegen/cli": "6.3.1",
-        "@graphql-codegen/typescript": "5.0.10",
+        "@graphql-codegen/cli": "7.1.0",
+        "@graphql-codegen/typescript": "6.0.2",
         "@graphql-codegen/typescript-graphql-request": "7.0.1",
-        "@graphql-codegen/typescript-operations": "5.1.0",
+        "@graphql-codegen/typescript-operations": "6.0.3",
         "@graphql-tools/schema": "10.0.32",
         "@graphql-tools/utils": "11.0.1",
         "@playwright/test": "1.60.0",
@@ -1539,13 +1539,13 @@
       "license": "MIT"
     },
     "node_modules/@graphql-codegen/add": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/add/-/add-6.0.1.tgz",
-      "integrity": "sha512-MSylSekjpVWbOBw2A/2ssk1fPY54sYb6Qk2C4AX5u7s2R+2pMQ9ws7DTXo8VU9qwTgWwVp6vGfdQ0AMpAn4Iug==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/add/-/add-7.0.1.tgz",
+      "integrity": "sha512-kWw6RMu9ysBw1wcgcgf9mOnswc5M3ekOApDTiaJC/UZNTEYins01srZHYTP7z3P/WlGGC844BRtjwh3U2kNd/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.3.0",
+        "@graphql-codegen/plugin-helpers": "^7.0.1",
         "tslib": "^2.8.0"
       },
       "engines": {
@@ -1555,19 +1555,73 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
+    "node_modules/@graphql-codegen/add/node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.0.1.tgz",
+      "integrity": "sha512-S2X0YT3XQbP2haqhIeku8GOXo2j8QuBu7BrLsOEHz4UeMu78y3rja1Q4ri3oJ0jq4dMgaQlazoVHI/A+FAKMGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "^11.0.0",
+        "change-case-all": "^2.1.0",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/add/node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/add/node_modules/change-case-all": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-2.1.0.tgz",
+      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "change-case": "^5.2.0",
+        "sponge-case": "^2.0.2",
+        "swap-case": "^3.0.2",
+        "title-case": "^3.0.3"
+      }
+    },
+    "node_modules/@graphql-codegen/add/node_modules/sponge-case": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-2.0.3.tgz",
+      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/add/node_modules/swap-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-3.0.3.tgz",
+      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@graphql-codegen/cli": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-6.3.1.tgz",
-      "integrity": "sha512-I5KkyX1SgQZPojMeQTRydB6fml4cysZq/mIdhNW4rmqdoOcTgdMPq1Tl+wtRp1VpBAOrBazJUJh1nAqJMMSPIQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-7.1.0.tgz",
+      "integrity": "sha512-2j1FzZtEnlHdQmOaDnTMGSNyu3RmDf4HGU9xbgpqDRSb+D8UYya2YFW1enIxhJccAQSLD9ACMwCXlB20wJXNiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "^7.18.13",
         "@babel/template": "^7.18.10",
         "@babel/types": "^7.18.13",
-        "@graphql-codegen/client-preset": "^5.3.0",
-        "@graphql-codegen/core": "^5.0.2",
-        "@graphql-codegen/plugin-helpers": "^6.3.0",
+        "@graphql-codegen/client-preset": "^6.0.1",
+        "@graphql-codegen/core": "^6.1.0",
+        "@graphql-codegen/plugin-helpers": "^7.0.1",
         "@graphql-tools/apollo-engine-loader": "^8.0.28",
         "@graphql-tools/code-file-loader": "^8.1.28",
         "@graphql-tools/git-loader": "^8.0.32",
@@ -1578,30 +1632,31 @@
         "@graphql-tools/merge": "^9.0.6",
         "@graphql-tools/url-loader": "^9.0.6",
         "@graphql-tools/utils": "^11.0.0",
-        "@inquirer/prompts": "^7.8.2",
+        "@inquirer/prompts": "^8.3.2",
         "@whatwg-node/fetch": "^0.10.0",
-        "chalk": "^4.1.0",
+        "chalk": "^5.6.0",
         "cosmiconfig": "^9.0.0",
-        "debounce": "^2.0.0",
-        "detect-indent": "^6.0.0",
+        "debounce": "^3.0.0",
+        "detect-indent": "^7.0.0",
         "graphql-config": "^5.1.6",
         "is-glob": "^4.0.1",
         "jiti": "^2.3.0",
         "json-to-pretty-yaml": "^1.2.2",
-        "listr2": "^9.0.0",
-        "log-symbols": "^4.0.0",
+        "listr2": "^10.2.1",
+        "log-symbols": "^7.0.0",
         "micromatch": "^4.0.5",
         "shell-quote": "^1.7.3",
         "string-env-interpolation": "^1.0.1",
-        "ts-log": "^2.2.3",
+        "ts-log": "^3.0.0",
         "tslib": "^2.4.0",
         "yaml": "^2.3.1",
-        "yargs": "^17.0.0"
+        "yargs": "^18.0.0"
       },
       "bin": {
-        "gql-gen": "cjs/bin.js",
-        "graphql-code-generator": "cjs/bin.js",
-        "graphql-codegen": "cjs/bin.js",
+        "gql-gen": "esm/bin.js",
+        "graphql-code-generator": "esm/bin.js",
+        "graphql-codegen": "esm/bin.js",
+        "graphql-codegen-cjs": "cjs/bin.js",
         "graphql-codegen-esm": "esm/bin.js"
       },
       "engines": {
@@ -1617,22 +1672,188 @@
         }
       }
     },
+    "node_modules/@graphql-codegen/cli/node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.0.1.tgz",
+      "integrity": "sha512-S2X0YT3XQbP2haqhIeku8GOXo2j8QuBu7BrLsOEHz4UeMu78y3rja1Q4ri3oJ0jq4dMgaQlazoVHI/A+FAKMGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "^11.0.0",
+        "change-case-all": "^2.1.0",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/change-case-all": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-2.1.0.tgz",
+      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "change-case": "^5.2.0",
+        "sponge-case": "^2.0.2",
+        "swap-case": "^3.0.2",
+        "title-case": "^3.0.3"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/sponge-case": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-2.0.3.tgz",
+      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/swap-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-3.0.3.tgz",
+      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
     "node_modules/@graphql-codegen/client-preset": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/client-preset/-/client-preset-5.3.0.tgz",
-      "integrity": "sha512-K9FON+j7qyxAUDuSGqI3ofb7lWTBs16oPTYpu14lhdL4DKZQSHLyc8EMYU9e3KcyQ/13gU/d6culOppzAuexLA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/client-preset/-/client-preset-6.0.1.tgz",
+      "integrity": "sha512-6wh0ZHG9WzBD6bE4AVOO6VCCMXK2orxHuXxaNKj+sj1w0qZ3Y3WIjZnqZLg6JZrHCIs/e+gy3T15Dc2pH8IbHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/template": "^7.20.7",
-        "@graphql-codegen/add": "^6.0.1",
-        "@graphql-codegen/gql-tag-operations": "5.2.0",
-        "@graphql-codegen/plugin-helpers": "^6.3.0",
-        "@graphql-codegen/typed-document-node": "^6.1.8",
-        "@graphql-codegen/typescript": "^5.0.10",
-        "@graphql-codegen/typescript-operations": "^5.1.0",
-        "@graphql-codegen/visitor-plugin-common": "^6.3.0",
+        "@graphql-codegen/add": "^7.0.1",
+        "@graphql-codegen/gql-tag-operations": "^6.0.1",
+        "@graphql-codegen/plugin-helpers": "^7.0.1",
+        "@graphql-codegen/typed-document-node": "^7.0.1",
+        "@graphql-codegen/typescript": "^6.0.2",
+        "@graphql-codegen/typescript-operations": "^6.0.3",
+        "@graphql-codegen/visitor-plugin-common": "^7.0.3",
         "@graphql-tools/documents": "^1.0.0",
         "@graphql-tools/utils": "^11.0.0",
         "@graphql-typed-document-node/core": "3.2.0",
@@ -1651,14 +1872,106 @@
         }
       }
     },
-    "node_modules/@graphql-codegen/core": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-5.0.2.tgz",
-      "integrity": "sha512-7RX0wwjoWPlLG/tUmpaTK91ZZqHcACNWpRL0nGnnJaJrORie9pgmX8JPrcwBgYiHSC+3ERo9xY91RFPem/VrpQ==",
+    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.0.1.tgz",
+      "integrity": "sha512-S2X0YT3XQbP2haqhIeku8GOXo2j8QuBu7BrLsOEHz4UeMu78y3rja1Q4ri3oJ0jq4dMgaQlazoVHI/A+FAKMGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.3.0",
+        "@graphql-tools/utils": "^11.0.0",
+        "change-case-all": "^2.1.0",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/visitor-plugin-common": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-7.0.4.tgz",
+      "integrity": "sha512-IESwu40Gpl+9x5vRGLsaYAWM9KRobnN74h+SB4EtfDrt0V87Q74ZzWZGmuS2m6A/fq7E/bS6YgSEMVACjaRUVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^7.0.1",
+        "@graphql-tools/optimize": "^2.0.0",
+        "@graphql-tools/relay-operation-optimizer": "^7.1.1",
+        "@graphql-tools/utils": "^11.0.0",
+        "auto-bind": "^5.0.0",
+        "change-case-all": "^2.1.0",
+        "dependency-graph": "^1.0.0",
+        "graphql-tag": "^2.11.0",
+        "parse-filepath": "^1.0.2",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/client-preset/node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@graphql-codegen/client-preset/node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/client-preset/node_modules/change-case-all": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-2.1.0.tgz",
+      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "change-case": "^5.2.0",
+        "sponge-case": "^2.0.2",
+        "swap-case": "^3.0.2",
+        "title-case": "^3.0.3"
+      }
+    },
+    "node_modules/@graphql-codegen/client-preset/node_modules/sponge-case": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-2.0.3.tgz",
+      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/client-preset/node_modules/swap-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-3.0.3.tgz",
+      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/core": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-6.1.0.tgz",
+      "integrity": "sha512-jReAzuCYlrSBJHW2bfBpDl/vMRCw0yQEoTvGi9K+3OTsazDXEQGOpCVfj8p/xO2h7ynu5Yrvzo0sUylVv0CnwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^7.0.1",
         "@graphql-tools/schema": "^10.0.0",
         "@graphql-tools/utils": "^11.0.0",
         "tslib": "^2.8.0"
@@ -1670,17 +1983,17 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-codegen/gql-tag-operations": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/gql-tag-operations/-/gql-tag-operations-5.2.0.tgz",
-      "integrity": "sha512-B9gtJ4ziqpIv+7mHqwjtpYLFOuv0GmmRGpNDoWKM2VIx4OQqgI84d6OHKYCVeO7yu3mUr0QPvUgkSyuLVrdukA==",
+    "node_modules/@graphql-codegen/core/node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.0.1.tgz",
+      "integrity": "sha512-S2X0YT3XQbP2haqhIeku8GOXo2j8QuBu7BrLsOEHz4UeMu78y3rja1Q4ri3oJ0jq4dMgaQlazoVHI/A+FAKMGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.3.0",
-        "@graphql-codegen/visitor-plugin-common": "^6.3.0",
         "@graphql-tools/utils": "^11.0.0",
-        "auto-bind": "~4.0.0",
+        "change-case-all": "^2.1.0",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
         "tslib": "^2.8.0"
       },
       "engines": {
@@ -1689,6 +2002,152 @@
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
+    },
+    "node_modules/@graphql-codegen/core/node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/core/node_modules/change-case-all": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-2.1.0.tgz",
+      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "change-case": "^5.2.0",
+        "sponge-case": "^2.0.2",
+        "swap-case": "^3.0.2",
+        "title-case": "^3.0.3"
+      }
+    },
+    "node_modules/@graphql-codegen/core/node_modules/sponge-case": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-2.0.3.tgz",
+      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/core/node_modules/swap-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-3.0.3.tgz",
+      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/gql-tag-operations": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/gql-tag-operations/-/gql-tag-operations-6.0.1.tgz",
+      "integrity": "sha512-eHYUIchZLG6G+kafeKnUByL2Nkmb8Uj2vg33UVLFj8XJ2coC4b1iRDWxCdTXbupZrN0FaM0QRRBLs3zBEAzcJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^7.0.1",
+        "@graphql-codegen/visitor-plugin-common": "^7.0.3",
+        "@graphql-tools/utils": "^11.0.0",
+        "auto-bind": "^5.0.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.0.1.tgz",
+      "integrity": "sha512-S2X0YT3XQbP2haqhIeku8GOXo2j8QuBu7BrLsOEHz4UeMu78y3rja1Q4ri3oJ0jq4dMgaQlazoVHI/A+FAKMGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "^11.0.0",
+        "change-case-all": "^2.1.0",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/@graphql-codegen/visitor-plugin-common": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-7.0.4.tgz",
+      "integrity": "sha512-IESwu40Gpl+9x5vRGLsaYAWM9KRobnN74h+SB4EtfDrt0V87Q74ZzWZGmuS2m6A/fq7E/bS6YgSEMVACjaRUVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^7.0.1",
+        "@graphql-tools/optimize": "^2.0.0",
+        "@graphql-tools/relay-operation-optimizer": "^7.1.1",
+        "@graphql-tools/utils": "^11.0.0",
+        "auto-bind": "^5.0.0",
+        "change-case-all": "^2.1.0",
+        "dependency-graph": "^1.0.0",
+        "graphql-tag": "^2.11.0",
+        "parse-filepath": "^1.0.2",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/change-case-all": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-2.1.0.tgz",
+      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "change-case": "^5.2.0",
+        "sponge-case": "^2.0.2",
+        "swap-case": "^3.0.2",
+        "title-case": "^3.0.3"
+      }
+    },
+    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/sponge-case": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-2.0.3.tgz",
+      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/swap-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-3.0.3.tgz",
+      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@graphql-codegen/plugin-helpers": {
       "version": "6.3.0",
@@ -1711,13 +2170,13 @@
       }
     },
     "node_modules/@graphql-codegen/schema-ast": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-5.0.2.tgz",
-      "integrity": "sha512-jl1F/9IjRkJisEb9B0ayG4QGqYlPldLRy8ojDdmL9NE1NsdB5ROfxQnSqyC3g+wuvBhWX7kZgMRQYn3RU1I5bA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-6.0.1.tgz",
+      "integrity": "sha512-P16b6XCWXfcrA4fkuAyqoy883USAULifv8YWgEOrNKDAnr2DR+Kr85jSomknIUTY39wiuvisv4/lrdXobwK6sA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.3.0",
+        "@graphql-codegen/plugin-helpers": "^7.0.1",
         "@graphql-tools/utils": "^11.0.0",
         "tslib": "^2.8.0"
       },
@@ -1728,17 +2187,17 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-codegen/typed-document-node": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-6.1.8.tgz",
-      "integrity": "sha512-+qDdiJSQ7Ol+vpLMAH8ZJok50CvlYxA6seQ7cwEa3emXt8MmH5hh3zdc9unQlPc7bynoJHRCgoKk7E0B7hry0w==",
+    "node_modules/@graphql-codegen/schema-ast/node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.0.1.tgz",
+      "integrity": "sha512-S2X0YT3XQbP2haqhIeku8GOXo2j8QuBu7BrLsOEHz4UeMu78y3rja1Q4ri3oJ0jq4dMgaQlazoVHI/A+FAKMGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.3.0",
-        "@graphql-codegen/visitor-plugin-common": "^6.3.0",
-        "auto-bind": "~4.0.0",
-        "change-case-all": "1.0.15",
+        "@graphql-tools/utils": "^11.0.0",
+        "change-case-all": "^2.1.0",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
         "tslib": "^2.8.0"
       },
       "engines": {
@@ -1748,18 +2207,164 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-codegen/typescript": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-5.0.10.tgz",
-      "integrity": "sha512-Pa8OFmL9TdhEYnLYJLYA9EhP8eEeivP/YDYq4Nb8LQaL7GXm4TGX8zELYaCM9Fu8M3iZb7iQGMt7qc+1lXz8XQ==",
+    "node_modules/@graphql-codegen/schema-ast/node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/schema-ast/node_modules/change-case-all": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-2.1.0.tgz",
+      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.3.0",
-        "@graphql-codegen/schema-ast": "^5.0.2",
-        "@graphql-codegen/visitor-plugin-common": "^6.3.0",
-        "auto-bind": "~4.0.0",
+        "change-case": "^5.2.0",
+        "sponge-case": "^2.0.2",
+        "swap-case": "^3.0.2",
+        "title-case": "^3.0.3"
+      }
+    },
+    "node_modules/@graphql-codegen/schema-ast/node_modules/sponge-case": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-2.0.3.tgz",
+      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/schema-ast/node_modules/swap-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-3.0.3.tgz",
+      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/typed-document-node": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-7.0.2.tgz",
+      "integrity": "sha512-vrjigzqpKsaQ2Ra4QBBuG9TcwG1O0pw9EOSFU0aj7mS2EK19vWs5N4rzwDDvHrQZW62wwqzUcqBoFitVBQqlmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^7.0.1",
+        "@graphql-codegen/visitor-plugin-common": "^7.0.4",
+        "auto-bind": "^5.0.0",
+        "change-case-all": "^2.1.0",
         "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typed-document-node/node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.0.1.tgz",
+      "integrity": "sha512-S2X0YT3XQbP2haqhIeku8GOXo2j8QuBu7BrLsOEHz4UeMu78y3rja1Q4ri3oJ0jq4dMgaQlazoVHI/A+FAKMGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "^11.0.0",
+        "change-case-all": "^2.1.0",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typed-document-node/node_modules/@graphql-codegen/visitor-plugin-common": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-7.0.4.tgz",
+      "integrity": "sha512-IESwu40Gpl+9x5vRGLsaYAWM9KRobnN74h+SB4EtfDrt0V87Q74ZzWZGmuS2m6A/fq7E/bS6YgSEMVACjaRUVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^7.0.1",
+        "@graphql-tools/optimize": "^2.0.0",
+        "@graphql-tools/relay-operation-optimizer": "^7.1.1",
+        "@graphql-tools/utils": "^11.0.0",
+        "auto-bind": "^5.0.0",
+        "change-case-all": "^2.1.0",
+        "dependency-graph": "^1.0.0",
+        "graphql-tag": "^2.11.0",
+        "parse-filepath": "^1.0.2",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typed-document-node/node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@graphql-codegen/typed-document-node/node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/typed-document-node/node_modules/change-case-all": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-2.1.0.tgz",
+      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "change-case": "^5.2.0",
+        "sponge-case": "^2.0.2",
+        "swap-case": "^3.0.2",
+        "title-case": "^3.0.3"
+      }
+    },
+    "node_modules/@graphql-codegen/typed-document-node/node_modules/sponge-case": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-2.0.3.tgz",
+      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/typed-document-node/node_modules/swap-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-3.0.3.tgz",
+      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-zyLfKsFJ7TRkQ0PyaUVuiAek9TSbtVJwwBoOuaE9RAWr45+9Y5W1LYldpiSTcyfxKVSIniE7Gj0V87qzrpdyYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^7.0.1",
+        "@graphql-codegen/schema-ast": "^6.0.1",
+        "@graphql-codegen/visitor-plugin-common": "^7.0.3",
+        "auto-bind": "^5.0.0",
+        "tslib": "~2.8.0"
       },
       "engines": {
         "node": ">=16"
@@ -1790,16 +2395,16 @@
       }
     },
     "node_modules/@graphql-codegen/typescript-operations": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-5.1.0.tgz",
-      "integrity": "sha512-JlmjbFl0EnsfMDIYvTE1Q0kAOrntVEZ+ZfBqWTP91g4e0F/TzuwJ/V4tiFmeDf5dx/rf9AK4VkPehIdxu7TYhw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-6.0.3.tgz",
+      "integrity": "sha512-5gnHdBgKkpKJOiqyKo37UfwigNtezfN94UI/NnyCROl6oDAyt0A+1VeS5cBlgRECdD/TQ1vjHCu14B41Sl7yLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.3.0",
-        "@graphql-codegen/typescript": "^5.0.10",
-        "@graphql-codegen/visitor-plugin-common": "^6.3.0",
-        "auto-bind": "~4.0.0",
+        "@graphql-codegen/plugin-helpers": "^7.0.1",
+        "@graphql-codegen/schema-ast": "^6.0.1",
+        "@graphql-codegen/visitor-plugin-common": "^7.0.3",
+        "auto-bind": "^5.0.0",
         "tslib": "^2.8.0"
       },
       "engines": {
@@ -1814,6 +2419,190 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.0.1.tgz",
+      "integrity": "sha512-S2X0YT3XQbP2haqhIeku8GOXo2j8QuBu7BrLsOEHz4UeMu78y3rja1Q4ri3oJ0jq4dMgaQlazoVHI/A+FAKMGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "^11.0.0",
+        "change-case-all": "^2.1.0",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/@graphql-codegen/visitor-plugin-common": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-7.0.4.tgz",
+      "integrity": "sha512-IESwu40Gpl+9x5vRGLsaYAWM9KRobnN74h+SB4EtfDrt0V87Q74ZzWZGmuS2m6A/fq7E/bS6YgSEMVACjaRUVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^7.0.1",
+        "@graphql-tools/optimize": "^2.0.0",
+        "@graphql-tools/relay-operation-optimizer": "^7.1.1",
+        "@graphql-tools/utils": "^11.0.0",
+        "auto-bind": "^5.0.0",
+        "change-case-all": "^2.1.0",
+        "dependency-graph": "^1.0.0",
+        "graphql-tag": "^2.11.0",
+        "parse-filepath": "^1.0.2",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/change-case-all": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-2.1.0.tgz",
+      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "change-case": "^5.2.0",
+        "sponge-case": "^2.0.2",
+        "swap-case": "^3.0.2",
+        "title-case": "^3.0.3"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/sponge-case": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-2.0.3.tgz",
+      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/swap-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-3.0.3.tgz",
+      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-7.0.1.tgz",
+      "integrity": "sha512-S2X0YT3XQbP2haqhIeku8GOXo2j8QuBu7BrLsOEHz4UeMu78y3rja1Q4ri3oJ0jq4dMgaQlazoVHI/A+FAKMGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "^11.0.0",
+        "change-case-all": "^2.1.0",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/@graphql-codegen/visitor-plugin-common": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-7.0.4.tgz",
+      "integrity": "sha512-IESwu40Gpl+9x5vRGLsaYAWM9KRobnN74h+SB4EtfDrt0V87Q74ZzWZGmuS2m6A/fq7E/bS6YgSEMVACjaRUVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^7.0.1",
+        "@graphql-tools/optimize": "^2.0.0",
+        "@graphql-tools/relay-operation-optimizer": "^7.1.1",
+        "@graphql-tools/utils": "^11.0.0",
+        "auto-bind": "^5.0.0",
+        "change-case-all": "^2.1.0",
+        "dependency-graph": "^1.0.0",
+        "graphql-tag": "^2.11.0",
+        "parse-filepath": "^1.0.2",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/change-case-all": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-2.1.0.tgz",
+      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "change-case": "^5.2.0",
+        "sponge-case": "^2.0.2",
+        "swap-case": "^3.0.2",
+        "title-case": "^3.0.3"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/sponge-case": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-2.0.3.tgz",
+      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/swap-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-3.0.3.tgz",
+      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@graphql-codegen/visitor-plugin-common": {
       "version": "6.3.0",
@@ -2404,30 +3193,29 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
-      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.6.tgz",
+      "integrity": "sha512-I/INw4sHGlVZ/afZOckpLiDP9SmbMl1g/GCqeHjLw1Afw/0PlRs2tRFgTGWmdI0hoNuWZn3y2iHNmG1vyECyQQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
-      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.0.tgz",
+      "integrity": "sha512-1HJt+3fqxblp/GQjdntSyoSHYBc0e3CzXVgjFpKA6qFLd9FHBBqwN8Co0xYH6t2JVUZrtFwZ4bBiwptkiLxyOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/ansi": "^2.0.6",
+        "@inquirer/core": "^11.2.0",
+        "@inquirer/figures": "^2.0.6",
+        "@inquirer/type": "^4.0.6"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2439,17 +3227,17 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
-      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.0.tgz",
+      "integrity": "sha512-USpeB76eqK7yGricDlGAupxWlp4a59qpeZOoNWaxO/nJln7agpJveyNkQ1d5u8YXG6TOqxZtQpKPORQQDrdVsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.2.0",
+        "@inquirer/type": "^4.0.6"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2461,23 +3249,22 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
-      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.0.tgz",
+      "integrity": "sha512-joR1YS2sI0us+9d0I8ViqFbrRLONO8CFTuyvBX4ZVBSch+VsZiugUABdrhBXXJR1VyEzvpz5SQCix3keETQ58g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
+        "@inquirer/ansi": "^2.0.6",
+        "@inquirer/figures": "^2.0.6",
+        "@inquirer/type": "^4.0.6",
         "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.3"
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^4.0.0",
+        "signal-exit": "^4.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2489,18 +3276,18 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
-      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.0.tgz",
+      "integrity": "sha512-/m+sgRmzSdK6HDtVnl3PmI6MnZC4O+LLezedoJcrX7mINhTjjb0hlC7aEDGZXkFTB4b5uQ0q59AhYTah88KbNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/external-editor": "^1.0.3",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.2.0",
+        "@inquirer/external-editor": "^3.0.1",
+        "@inquirer/type": "^4.0.6"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2512,18 +3299,17 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
-      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.0.tgz",
+      "integrity": "sha512-fR7g4BVnIcs+4NApF6C5byflNM/EULxSxsv/2Jvg+gmop0R6eBIPvZqE6RYnTy1tQTFnf9wyHkwNoQSZbofaGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/core": "^11.2.0",
+        "@inquirer/type": "^4.0.6"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2535,17 +3321,17 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
-      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.1.tgz",
+      "integrity": "sha512-tam+Gwjsxg2sx3iUVPkAnhKT/yrk2rd2NAa7XJU/J8OYpU0ifXsnp12xlvzp/DCpWBXVv+vLQsqnpAWwUcWD5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chardet": "^2.1.1",
-        "iconv-lite": "^0.7.0"
+        "iconv-lite": "^0.7.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2557,27 +3343,27 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.6.tgz",
+      "integrity": "sha512-dsZgQtH2t5Q6ah3aPbZbeEZAxsD9qQu0DXf01AltuEfRTm+NoLN6+rLVbr+4edeEbNCp/wBNM6mALRWtsQpfkw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
-      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.0.tgz",
+      "integrity": "sha512-sVZCz6P6e8tW5g2bSFel1oLpa6jK/u7BexFfrgTqR8syIdnHqy+iopnlSbYBZMsCK52chLjhGNBxt0eRqhsghw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.2.0",
+        "@inquirer/type": "^4.0.6"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2589,17 +3375,17 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
-      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.1.0.tgz",
+      "integrity": "sha512-VMXB/XejCbaSTf9Xucl7dqjzzsaGsrs6XwSYXPbGZ2QbSuq/Gz8XamhSi9ClRubNXZlGry9xVg1tKkJdTDgCtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.2.0",
+        "@inquirer/type": "^4.0.6"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2611,18 +3397,18 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
-      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.0.tgz",
+      "integrity": "sha512-5tqRuKCDIUxdPxTI/CuLnh914kz+WMPmURHKnZgui9gk43ebudEsdu4EwSn1CPSi5R+17YpBG+ba/YqTnRAcJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/ansi": "^2.0.6",
+        "@inquirer/core": "^11.2.0",
+        "@inquirer/type": "^4.0.6"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2634,25 +3420,25 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
-      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.5.0.tgz",
+      "integrity": "sha512-pLjXOnY4y3R1mgyHP3pXD/8eXejp+L/dde/0N2NLKgKfMstqhNZrpvs7Wkzbl9FYFQh10LRQ7QZwq+cz9rrhyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^4.3.2",
-        "@inquirer/confirm": "^5.1.21",
-        "@inquirer/editor": "^4.2.23",
-        "@inquirer/expand": "^4.0.23",
-        "@inquirer/input": "^4.3.1",
-        "@inquirer/number": "^3.0.23",
-        "@inquirer/password": "^4.0.23",
-        "@inquirer/rawlist": "^4.1.11",
-        "@inquirer/search": "^3.2.2",
-        "@inquirer/select": "^4.4.2"
+        "@inquirer/checkbox": "^5.2.0",
+        "@inquirer/confirm": "^6.1.0",
+        "@inquirer/editor": "^5.2.0",
+        "@inquirer/expand": "^5.1.0",
+        "@inquirer/input": "^5.1.0",
+        "@inquirer/number": "^4.1.0",
+        "@inquirer/password": "^5.1.0",
+        "@inquirer/rawlist": "^5.3.0",
+        "@inquirer/search": "^4.2.0",
+        "@inquirer/select": "^5.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2664,18 +3450,17 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
-      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.0.tgz",
+      "integrity": "sha512-p+vAeTAD+cGXjGleP1F5LXrX2ISxNDZm+lqeBpnJausNLSZskZZkcggwhomqP8Igx9oIjnoeOrw98xvdFvdm2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/core": "^11.2.0",
+        "@inquirer/type": "^4.0.6"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2687,19 +3472,18 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
-      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.0.tgz",
+      "integrity": "sha512-ByURoSGIaSl5O5Q0AmYmVmUsXbMUcBGNoA3FRL7TOyiA22IeFHymJKRkuILbOIlJwqnBk7AnPpseodyFUBzg+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/core": "^11.2.0",
+        "@inquirer/figures": "^2.0.6",
+        "@inquirer/type": "^4.0.6"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2711,20 +3495,19 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
-      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.0.tgz",
+      "integrity": "sha512-6IzkcmEbEXfgVbxZ2d1UyJFbCBoc6dTofulFmrYuomIp88HXiVqRbqbg4/mbfZhvnNo6xYmnYo2AEmDof6fQkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/ansi": "^2.0.6",
+        "@inquirer/core": "^11.2.0",
+        "@inquirer/figures": "^2.0.6",
+        "@inquirer/type": "^4.0.6"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2736,13 +3519,13 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
-      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.6.tgz",
+      "integrity": "sha512-J+9tdxOskuYuGjsvGaq00AamhDgjR7anhEW2dP4QdQpFCMPngCeC/bCYWQ5NsMWZRdsy53is7kAHb/+7cwDk2g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -5187,13 +5970,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/common-tags": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -5465,13 +6241,13 @@
       "license": "MIT"
     },
     "node_modules/debounce": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
-      "integrity": "sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-3.0.0.tgz",
+      "integrity": "sha512-64byRbF0/AirwbuHqB3/ZpMG9/nckDa6ZA0yd6UnaQNwbbemCOwvz2sL5sjXLHhZHADyiwLm0M5qMhltUUx+TA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5566,13 +6342,16 @@
       }
     },
     "node_modules/detect-indent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
-      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-7.0.2.tgz",
+      "integrity": "sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/detect-libc": {
@@ -6661,9 +7440,9 @@
       }
     },
     "node_modules/fast-wrap-ansi": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
-      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6884,9 +7663,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7942,13 +8721,13 @@
       }
     },
     "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8562,77 +9341,20 @@
       "license": "MIT"
     },
     "node_modules/listr2": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
-      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz",
+      "integrity": "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cli-truncate": "^5.0.0",
-        "colorette": "^2.0.20",
-        "eventemitter3": "^5.0.1",
+        "cli-truncate": "^5.2.0",
+        "eventemitter3": "^5.0.4",
         "log-update": "^6.1.0",
         "rfdc": "^1.4.1",
-        "wrap-ansi": "^9.0.0"
+        "wrap-ansi": "^10.0.0"
       },
       "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/listr2/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/listr2/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/listr2/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/listr2/node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+        "node": ">=22.13.0"
       }
     },
     "node_modules/locate-path": {
@@ -8672,17 +9394,17 @@
       "license": "MIT"
     },
     "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
+        "is-unicode-supported": "^2.0.0",
+        "yoctocolors": "^2.1.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9024,103 +9746,6 @@
         }
       }
     },
-    "node_modules/msw/node_modules/@inquirer/ansi": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
-      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      }
-    },
-    "node_modules/msw/node_modules/@inquirer/confirm": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.11.tgz",
-      "integrity": "sha512-pTpHjg0iEIRMYV/7oCZUMf27/383E6Wyhfc/MY+AVQGEoUobffIYWOK9YLP2XFRGz/9i6WlTQh1CkFVIo2Y7XA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^11.1.8",
-        "@inquirer/type": "^4.0.5"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/msw/node_modules/@inquirer/core": {
-      "version": "11.1.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.8.tgz",
-      "integrity": "sha512-/u+yJk2pOKNDOh1ZgdUH2RQaRx6OOH4I0uwL95qPvTFTIL38YBsuSC4r1yXBB3Q6JvNqFFc202gk0Ew79rrcjA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^2.0.5",
-        "@inquirer/figures": "^2.0.5",
-        "@inquirer/type": "^4.0.5",
-        "cli-width": "^4.1.0",
-        "fast-wrap-ansi": "^0.2.0",
-        "mute-stream": "^3.0.0",
-        "signal-exit": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/msw/node_modules/@inquirer/figures": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
-      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      }
-    },
-    "node_modules/msw/node_modules/@inquirer/type": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
-      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/msw/node_modules/mute-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
-      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/msw/node_modules/type-fest": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
@@ -9138,13 +9763,13 @@
       }
     },
     "node_modules/mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-4.0.0.tgz",
+      "integrity": "sha512-gSrprq0fJ3EiOErzjdIZrjysVVmJ4uu1QWfCDss5LypA5OXvrMje5Ym5z6V6RLyJ2eF87lasX7t6a0AnFvZblg==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/nanoid": {
@@ -10795,9 +11420,9 @@
       "license": "MIT"
     },
     "node_modules/string-width": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11246,11 +11871,15 @@
       }
     },
     "node_modules/ts-log": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.2.7.tgz",
-      "integrity": "sha512-320x5Ggei84AxzlXp91QkIGSw5wgaLT6GeAH0KsqDmRZdVWW2OiSeVvElVoatk3f7nicwXlElXsoFkARiGE2yg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-3.0.2.tgz",
+      "integrity": "sha512-esq6hx2lM66sQV1YcFkIYTqrWWabmqBqobKHyn1CswdI5FgfQhkmiKiRWVGBNlIbdjBxEIkNvMIwLKKPgRYZLQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=20",
+        "npm": ">=10"
+      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -12240,56 +12869,34 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "node": ">=12"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/ws": {
@@ -12444,10 +13051,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/yoctocolors-cjs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -58,10 +58,10 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.12",
     "@eslint/js": "9.39.4",
-    "@graphql-codegen/cli": "6.3.1",
-    "@graphql-codegen/typescript": "5.0.10",
+    "@graphql-codegen/cli": "7.1.0",
+    "@graphql-codegen/typescript": "6.0.2",
     "@graphql-codegen/typescript-graphql-request": "7.0.1",
-    "@graphql-codegen/typescript-operations": "5.1.0",
+    "@graphql-codegen/typescript-operations": "6.0.3",
     "@graphql-tools/schema": "10.0.32",
     "@graphql-tools/utils": "11.0.1",
     "@playwright/test": "1.60.0",

--- a/src/features/authors/AuthorHistory.tsx
+++ b/src/features/authors/AuthorHistory.tsx
@@ -98,7 +98,7 @@ export const AuthorHistory: React.FC<{ authorId: string }> = ({ authorId }) => {
             <Text>
               <strong>Yomi:</strong> {selectedEvent.yomi ?? "-"}
             </Text>
-            {selectedEvent.extra && (
+            {selectedEvent.extra != null && (
               <Text>
                 <strong>Extra:</strong> {JSON.stringify(selectedEvent.extra)}
               </Text>

--- a/src/features/books/BookHistory.tsx
+++ b/src/features/books/BookHistory.tsx
@@ -162,7 +162,7 @@ export const BookHistory: React.FC<BookHistoryProps> = ({
             <Text>
               <strong>Priority:</strong> {selectedEvent.priority ?? "-"}
             </Text>
-            {selectedEvent.extra && (
+            {selectedEvent.extra != null && (
               <Text>
                 <strong>Extra:</strong> {JSON.stringify(selectedEvent.extra)}
               </Text>


### PR DESCRIPTION
Bump GraphQL code generator packages to their latest major versions:

- `@graphql-codegen/cli` 6.3.1 → 7.1.0
- `@graphql-codegen/typescript` 5.0.10 → 6.0.2
- `@graphql-codegen/typescript-operations` 5.1.0 → 6.0.3

### Breaking changes handled

- `typescript-operations` v6 is decoupled from the `typescript` plugin, so `codegen.yml` now splits output into `graphql-schema.ts` (types) and `graphql-request.ts` (operations + SDK), using `importSchemaTypesFrom` to avoid duplicate identifiers.
- The default custom scalar type changed from `any` to `unknown`. Updated `AuthorHistory.tsx` and `BookHistory.tsx` to use `!= null` checks for JSON scalar fields instead of truthiness checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * Author History と Book History のイベント詳細表示で、Extra フィールドの表示条件を改善しました。null/undefined 以外の値が正しく表示されるようになります。

* **Chores**
  * GraphQL Code Generator パッケージを最新バージョンにアップデートしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->