### PR TITLE
Separate msw updates in Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -30,6 +30,11 @@
       "matchDatasources": ["github-releases", "node-version"],
       "matchUpdateTypes": ["pin"],
       "enabled": false
+    },
+    {
+      // Separate msw updates into individual PRs because grouped updates often fail.
+      "matchDepNames": ["msw"],
+      "groupName": null
     }
   ],
   "customManagers": [


### PR DESCRIPTION
MSW の更新を grouped updates から除外し、個別の PR として作成されるようにします。