### PR TITLE
Add global minimumReleaseAge to Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,6 +4,9 @@
     "config:best-practices",
     ":pinAllExceptPeerDependencies",
   ],
+  // config:best-practices already applies minimumReleaseAge for npm via security:minimumReleaseAgeNpm.
+  // This global setting ensures other managers (e.g. github-actions, docker, github-tags) also wait.
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       // Group minor/patch updates by manager (e.g. npm, github-actions).


### PR DESCRIPTION
Apply minimumReleaseAge: "3 days" globally so that not only npm packages (already covered by security:minimumReleaseAgeNpm in config:best-practices) but also GitHub Actions, Docker images, and other datasources wait 3 days before Renovate suggests an update.