### PR TITLE
Update Renovate config to use managerFilePatterns

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -40,7 +40,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["bookshelf-api\\.version"],
+      "managerFilePatterns": ["/bookshelf-api\\.version/"],
       "matchStrings": ["(?<currentValue>.+)"],
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "hiterm/bookshelf-api"


### PR DESCRIPTION
Migrate the deprecated \fileMatch\ property to \managerFilePatterns\ in the custom manager configuration, following the Renovate schema migration.