### PR TITLE
Update TypeScript to 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "mantine-form-zod-resolver": "1.3.0",
         "react": "19.2.6",
         "react-dom": "19.2.6",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "zod": "4.4.3"
       },
       "devDependencies": {
@@ -10190,7 +10190,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "mantine-form-zod-resolver": "1.3.0",
     "react": "19.2.6",
     "react-dom": "19.2.6",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
- Update TypeScript from 5.9.3 to 6.0.3
- Update tsconfig target from es5 to es2020 to resolve TS5107 deprecation error in TypeScript 6
- All pre-commit checks pass (generate, lint:fix, test, typecheck)