### PR TITLE
Configure Renovate Node memory

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,6 +7,9 @@
   // config:best-practices already applies minimumReleaseAge for npm via security:minimumReleaseAgeNpm.
   // This global setting ensures other managers (e.g. github-actions, docker, github-tags) also wait.
   "minimumReleaseAge": "3 days",
+  "toolSettings": {
+    "nodeMaxMemory": 2048,
+  },
   "packageRules": [
     {
       // Group minor/patch updates by manager (e.g. npm, github-actions).


### PR DESCRIPTION
## Summary

- configure Mend-hosted Renovate to allow Node.js up to 2 GB of memory
- apply the limit to pnpm commands through `toolSettings.nodeMaxMemory`

## Why

Large dependency updates can cause pnpm to hit the Mend-hosted timeout or
kernel out-of-memory limit. Renovate recommends tuning this repository-level
setting for pnpm and Yarn projects.

## Impact

Renovate dependency-update jobs can use up to 2 GB of Node.js memory. This does
not affect application runtime behavior.

## Validation

- `pnpm run generate`
- `pnpm run lint:fix`
- `TZ=UTC pnpm run test` (95 tests passed)
- `pnpm run typecheck`
