### PR TITLE
Exclude API from release age

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -41,6 +41,12 @@
       // Separate msw updates into individual PRs because grouped updates often fail.
       "matchDepNames": ["msw"],
       "groupName": null
+    },
+    {
+      // Internal API releases can be consumed without the global waiting period.
+      "matchPackageNames": ["hiterm/bookshelf-api"],
+      "matchDatasources": ["github-tags"],
+      "minimumReleaseAge": null
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary

- Exclude `hiterm/bookshelf-api` GitHub tag updates from the global three-day minimum release age.
- Limit the override to the `github-tags` datasource used by the custom manager.

## Why

Bookshelf API is an internal dependency and can be consumed without waiting for the global release-age period intended for external dependencies.

## Impact

Renovate can propose Bookshelf API updates immediately after a tag is published. Other dependencies continue to use the configured minimum release age.

## Validation

- `git diff --check`
- Full pre-commit checks were skipped at the user's request.
