### PR TITLE
Document Codex gh sandbox behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,16 @@ Never commit directly to `main`.
 - Always use `git --no-pager` for git commands to avoid opening a pager
 - Example: `git --no-pager log`, `git --no-pager diff`, `git --no-pager status`
 
+## GitHub CLI Authentication
+
+When running as Codex, do not immediately conclude that GitHub CLI is
+unauthenticated when a `gh` command fails with an authentication or
+network-related error. Sandbox restrictions can cause misleading failures.
+
+Retry the required command with escalated sandbox permissions first. Only ask
+the user to re-authenticate when the authentication failure also occurs outside
+the sandbox.
+
 ## Communication
 
 - Be concise and direct


### PR DESCRIPTION
## What changed

- Document how Codex should handle GitHub CLI authentication and network errors
  that may be caused by sandbox restrictions.
- Require retrying the command with escalated sandbox permissions before asking
  the user to re-authenticate.

## Why

This ports hiterm/bookshelf-api#283 so agent behavior remains consistent across
the Bookshelf repositories.

## Impact

Codex will avoid reporting misleading GitHub CLI authentication failures when
the actual cause is sandbox isolation.

## Validation

- `pnpm run lint:fix`
