### PR TITLE
Use canonical mutation payloads

### DIFF
--- a/.agent/plans/20260716-unify-mutation-payloads.md
+++ b/.agent/plans/20260716-unify-mutation-payloads.md
@@ -1,0 +1,70 @@
+# Migrate the frontend to canonical mutation payloads
+
+This ExecPlan is a living document maintained according to `.agent/PLANS.md`. The `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` sections must remain current.
+
+## Purpose / Big Picture
+
+The frontend currently reads compatibility fields directly from GraphQL mutation payloads. After this work, it reads created and updated books and authors from `book` and `author`, and deleted identifiers from `bookId` and `authorId`. Users retain the same CRUD behavior while the API can safely remove duplicate compatibility fields.
+
+## Progress
+
+- [x] (2026-07-16) Milestone 1: Inspect the mutation documents, consumers, and both mock implementations and establish the coordinated rollout order.
+  - [x] plan updated
+- [x] (2026-07-16) Milestone 2: Migrate documents, consumers, mocks, generated artifacts, and tests.
+  - [x] plan updated
+- [ ] Milestone 3: Run generation, linting, unit tests, type checking, and relevant E2E tests, then commit and publish the frontend PR (completed: all mandatory checks pass; E2E cannot launch because the host lacks `libnspr4.so`; remaining: commit and publish).
+  - [ ] plan updated
+- [ ] Milestone 4: Validate the frontend against the alias-free candidate API schema (completed: GraphQL Codegen accepts all mutation documents; remaining: full typecheck is blocked by the candidate schema's unrelated pre-existing requirement for `Author.yomi`).
+  - [ ] plan updated
+
+## Surprises & Discoveries
+
+- Observation: Both MSW handlers and executable mock resolvers currently return entity objects directly, matching the deprecated aliases rather than the payload object.
+  Evidence: `src/mocks/handlers.ts` spreads books and authors at the mutation root, and `e2e-mock-api/resolvers.ts` returns store entities directly.
+- Observation: Playwright cannot launch the downloaded Chromium on this host because `libnspr4.so` is missing, and `playwright install-deps` requires an unavailable sudo password.
+  Evidence: All targeted E2E cases stop during `browserType.launch` before loading a page; unit tests and TypeScript checks succeed.
+- Observation: The candidate API SDL is ahead of the released frontend SDL in an unrelated area: it makes `Author.yomi` required while existing frontend fixtures omit it.
+  Evidence: GraphQL Codegen succeeds against the candidate SDL, then full typecheck reports only missing `yomi` errors in existing history/list fixtures and mappings.
+
+## Decision Log
+
+- Decision: Migrate and publish the frontend before removing API aliases.
+  Rationale: The current API supports canonical selections, but an alias-free API rejects the old frontend during GraphQL validation.
+  Date/Author: 2026-07-16 / Codex
+- Decision: Run existing mutation CRUD E2E coverage rather than add a new endpoint E2E test.
+  Rationale: No endpoint is being added; the behavior change is a response-shape migration already exercised by existing CRUD flows.
+  Date/Author: 2026-07-16 / Codex
+
+## Outcomes & Retrospective
+
+The frontend now uses canonical mutation response shapes in operations, production consumers, and both test-double implementations. Generation, formatting, 95 unit tests, and all TypeScript project checks pass against the released schema. Browser E2E and a full candidate-schema typecheck remain environment/version blockers documented above; mutation document generation against the alias-free schema succeeds.
+
+## Context and Orientation
+
+Handwritten operations live under `src/graphql/` and generate TypeScript SDK artifacts through `pnpm run generate`. Production callers that consume created IDs live in `src/features/books/BookAddButton.tsx` and `src/features/books/BookDetailEdit.tsx`. Browser demo tests use MSW handlers in `src/mocks/handlers.ts`; Playwright mock-API tests use executable GraphQL resolvers in `e2e-mock-api/resolvers.ts`.
+
+## Plan of Work
+
+Change create and update selections to nest entity fields under `book` or `author`, and delete selections to request the descriptive identifier. Update production ID reads and make both mock layers return payload objects with the same nesting. Regenerate artifacts, repair affected expectations, and run all repository-mandated checks. Finally, generate or validate with the candidate alias-free API schema and confirm type checking remains clean.
+
+## Concrete Steps
+
+From the `bookshelf` repository run `pnpm run generate`, `pnpm run lint:fix`, `pnpm run test`, and `pnpm run typecheck`. Discover the relevant Playwright project names from configuration and run the mutation-related mock API and demo-mode specs. Before committing, rerun the four mandatory commands in their required order.
+
+## Validation and Acceptance
+
+Generated operations must contain no direct compatibility selections. Unit and relevant E2E tests must show that create, update, and delete still work with canonical payload objects. Type checking must pass against the candidate API schema as well as the normal generated artifacts.
+
+## Idempotence and Recovery
+
+Generation and validation commands are repeatable. If candidate-schema generation changes artifacts unexpectedly, inspect the diff and rerun normal generation only after preserving evidence of compatibility. No database or destructive migration is involved.
+
+## Artifacts and Notes
+
+The API change is tracked separately in `bookshelf-api/.agent/plans/20260716-unify-mutation-payloads.md`. Deployment order is frontend first, API second.
+
+## Interfaces and Dependencies
+
+No dependency changes are needed. The required response interfaces are `createBook.book`, `updateBook.book`, `createAuthor.author`, `updateAuthor.author`, `deleteBook.bookId`, and `deleteAuthor.authorId`.
+
+Plan revision note (2026-07-16): Recorded the completed migration and mandatory checks, plus the Playwright host-library and unrelated candidate-schema `Author.yomi` blockers.

--- a/.agent/plans/20260716-unify-mutation-payloads.md
+++ b/.agent/plans/20260716-unify-mutation-payloads.md
@@ -12,8 +12,8 @@ The frontend currently reads compatibility fields directly from GraphQL mutation
   - [x] plan updated
 - [x] (2026-07-16) Milestone 2: Migrate documents, consumers, mocks, generated artifacts, and tests.
   - [x] plan updated
-- [ ] Milestone 3: Run generation, linting, unit tests, type checking, and relevant E2E tests, then commit and publish the frontend PR (completed: all mandatory checks pass; E2E cannot launch because the host lacks `libnspr4.so`; remaining: commit and publish).
-  - [ ] plan updated
+- [x] (2026-07-16) Milestone 3: Run generation, linting, unit tests, and type checking, then commit and publish frontend draft PR #286; record that relevant E2E cannot launch because the host lacks `libnspr4.so`.
+  - [x] plan updated
 - [ ] Milestone 4: Validate the frontend against the alias-free candidate API schema (completed: GraphQL Codegen accepts all mutation documents; remaining: full typecheck is blocked by the candidate schema's unrelated pre-existing requirement for `Author.yomi`).
   - [ ] plan updated
 
@@ -37,7 +37,7 @@ The frontend currently reads compatibility fields directly from GraphQL mutation
 
 ## Outcomes & Retrospective
 
-The frontend now uses canonical mutation response shapes in operations, production consumers, and both test-double implementations. Generation, formatting, 95 unit tests, and all TypeScript project checks pass against the released schema. Browser E2E and a full candidate-schema typecheck remain environment/version blockers documented above; mutation document generation against the alias-free schema succeeds.
+The frontend now uses canonical mutation response shapes in operations, production consumers, and both test-double implementations. Generation, formatting, 95 unit tests, and all TypeScript project checks pass against the released schema. Draft PR #286 publishes the migration. Browser E2E and a full candidate-schema typecheck remain environment/version blockers documented above; mutation document generation against the alias-free schema succeeds.
 
 ## Context and Orientation
 
@@ -67,4 +67,4 @@ The API change is tracked separately in `bookshelf-api/.agent/plans/20260716-uni
 
 No dependency changes are needed. The required response interfaces are `createBook.book`, `updateBook.book`, `createAuthor.author`, `updateAuthor.author`, `deleteBook.bookId`, and `deleteAuthor.authorId`.
 
-Plan revision note (2026-07-16): Recorded the completed migration and mandatory checks, plus the Playwright host-library and unrelated candidate-schema `Author.yomi` blockers.
+Plan revision note (2026-07-16): Recorded draft PR #286 after publishing the validated frontend migration; retained the Playwright host-library and unrelated candidate-schema `Author.yomi` blockers.

--- a/e2e-mock-api/resolvers.ts
+++ b/e2e-mock-api/resolvers.ts
@@ -21,7 +21,7 @@ export const createResolvers = (mockStore: MockStore) => ({
     createAuthor: (
       _: unknown,
       { authorData }: { authorData: { name: string } },
-    ) => mockStore.createAuthor(authorData.name),
+    ) => ({ author: mockStore.createAuthor(authorData.name) }),
     updateAuthor: (
       _: unknown,
       { authorData }: { authorData: { id: string; name: string } },
@@ -30,29 +30,35 @@ export const createResolvers = (mockStore: MockStore) => ({
       if (!updated) {
         throw new Error(`Author not found: ${authorData.id}`);
       }
-      return updated;
+      return { author: updated };
     },
     deleteAuthor: (_: unknown, { authorId }: { authorId: string }) => {
       const deleted = mockStore.deleteAuthor(authorId);
       if (!deleted) {
         throw new Error(`Author not found: ${authorId}`);
       }
-      return { id: authorId };
+      return { authorId };
     },
     createBook: (
       _: unknown,
       { bookData }: { bookData: Parameters<typeof mockStore.createBook>[0] },
-    ) => mockStore.createBook(bookData),
+    ) => ({ book: mockStore.createBook(bookData) }),
     updateBook: (
       _: unknown,
       { bookData }: { bookData: Parameters<typeof mockStore.updateBook>[0] },
-    ) => mockStore.updateBook(bookData),
+    ) => {
+      const updated = mockStore.updateBook(bookData);
+      if (!updated) {
+        throw new Error(`Book not found: ${bookData.id}`);
+      }
+      return { book: updated };
+    },
     deleteBook: (_: unknown, { bookId }: { bookId: string }) => {
       const deleted = mockStore.deleteBook(bookId);
       if (!deleted) {
         throw new Error(`Book not found: ${bookId}`);
       }
-      return { id: bookId };
+      return { bookId };
     },
   },
   Book: {

--- a/src/features/books/BookAddButton.tsx
+++ b/src/features/books/BookAddButton.tsx
@@ -33,7 +33,7 @@ export const BookAddButton: React.FC = () => {
         value.authors,
         async (name) => {
           const result = await createAuthorMutation.mutateAsync({ name });
-          return result.createAuthor.id;
+          return result.createAuthor.author.id;
         },
       );
     } catch (error) {
@@ -64,7 +64,7 @@ export const BookAddButton: React.FC = () => {
             <LinkButton
               linkOptions={{
                 to: "/books/$id",
-                params: { id: result.createBook.id },
+                params: { id: result.createBook.book.id },
               }}
             >
               Move

--- a/src/features/books/BookDetailEdit.tsx
+++ b/src/features/books/BookDetailEdit.tsx
@@ -27,7 +27,7 @@ export const BookDetailEdit: React.FC<{ book: Book }> = (props) => {
         values.authors,
         async (name) => {
           const result = await createAuthorMutation.mutateAsync({ name });
-          return result.createAuthor.id;
+          return result.createAuthor.author.id;
         },
       );
     } catch (error) {

--- a/src/graphql/createAuthor.graphql
+++ b/src/graphql/createAuthor.graphql
@@ -1,5 +1,7 @@
 mutation createAuthor($authorData: CreateAuthorInput!) {
   createAuthor(authorData: $authorData) {
-    id
+    author {
+      id
+    }
   }
 }

--- a/src/graphql/createBook.graphql
+++ b/src/graphql/createBook.graphql
@@ -1,5 +1,7 @@
 mutation createBook($bookData: CreateBookInput!) {
   createBook(bookData: $bookData) {
-    id
+    book {
+      id
+    }
   }
 }

--- a/src/graphql/deletBook.graphql
+++ b/src/graphql/deletBook.graphql
@@ -1,5 +1,5 @@
 mutation deleteBook($bookId: ID!) {
   deleteBook(bookId: $bookId) {
-    id
+    bookId
   }
 }

--- a/src/graphql/deleteAuthor.graphql
+++ b/src/graphql/deleteAuthor.graphql
@@ -1,5 +1,5 @@
 mutation deleteAuthor($authorId: ID!) {
   deleteAuthor(authorId: $authorId) {
-    id
+    authorId
   }
 }

--- a/src/graphql/updateAuthor.graphql
+++ b/src/graphql/updateAuthor.graphql
@@ -1,6 +1,8 @@
 mutation updateAuthor($authorData: UpdateAuthorInput!) {
   updateAuthor(authorData: $authorData) {
-    id
-    name
+    author {
+      id
+      name
+    }
   }
 }

--- a/src/graphql/updateBook.graphql
+++ b/src/graphql/updateBook.graphql
@@ -1,5 +1,7 @@
 mutation updateBook($bookData: UpdateBookInput!) {
   updateBook(bookData: $bookData) {
-    id
+    book {
+      id
+    }
   }
 }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -250,8 +250,10 @@ export const handlers = [
     return HttpResponse.json({
       data: {
         createAuthor: {
-          __typename: "Author",
-          ...author,
+          author: {
+            __typename: "Author",
+            ...author,
+          },
         },
       },
     });
@@ -281,8 +283,10 @@ export const handlers = [
     return HttpResponse.json({
       data: {
         updateAuthor: {
-          __typename: "Author",
-          ...author,
+          author: {
+            __typename: "Author",
+            ...author,
+          },
         },
       },
     });
@@ -303,7 +307,7 @@ export const handlers = [
       );
     }
     return HttpResponse.json({
-      data: { deleteAuthor: { id: variables.authorId } },
+      data: { deleteAuthor: { authorId: variables.authorId } },
     });
   }),
 
@@ -344,9 +348,11 @@ export const handlers = [
     return HttpResponse.json({
       data: {
         createBook: {
-          __typename: "Book",
-          ...book,
-          authors: resolveBookAuthors(book),
+          book: {
+            __typename: "Book",
+            ...book,
+            authors: resolveBookAuthors(book),
+          },
         },
       },
     });
@@ -398,9 +404,11 @@ export const handlers = [
     return HttpResponse.json({
       data: {
         updateBook: {
-          __typename: "Book",
-          ...book,
-          authors: resolveBookAuthors(book),
+          book: {
+            __typename: "Book",
+            ...book,
+            authors: resolveBookAuthors(book),
+          },
         },
       },
     });
@@ -421,7 +429,7 @@ export const handlers = [
       );
     }
     return HttpResponse.json({
-      data: { deleteBook: { id: variables.bookId } },
+      data: { deleteBook: { bookId: variables.bookId } },
     });
   }),
 ];


### PR DESCRIPTION
## What changed

- Select created and updated entities through `book` and `author`
- Select deleted identifiers through `bookId` and `authorId`
- Update production consumers, MSW handlers, and executable mock resolvers to match the canonical payload shape
- Add an ExecPlan documenting the coordinated frontend-first rollout

## Why

The API currently exposes temporary compatibility aliases alongside canonical nested payload fields. Migrating the known frontend first allows the API aliases to be removed without interrupting CRUD behavior.

## Validation

- `pnpm run generate`
- `pnpm run lint:fix`
- `pnpm run test` — 95 passed
- `pnpm run typecheck`
- GraphQL Codegen succeeds against the alias-free candidate API SDL

## Environment notes

Targeted Playwright CRUD E2E could not launch on this host because `libnspr4.so` is unavailable and installing OS dependencies requires sudo. Full candidate-SDL type checking also exposes an unrelated existing version difference: the candidate schema requires `Author.yomi`, while current frontend fixtures and mappings omit it.