### PR TITLE
Use author reading field

### DIFF
--- a/e2e-demo-mode/authors.spec.ts
+++ b/e2e-demo-mode/authors.spec.ts
@@ -12,6 +12,7 @@ test("creates author and displays in list", async ({ page }) => {
 
   // CREATE - 著者を作成
   await page.getByLabel("名前").fill("新規テスト著者");
+  await page.getByLabel("読み仮名").fill("しんきてすとちょしゃ");
   await page.getByRole("button", { name: "登録" }).click();
 
   // 一覧に表示されるか確認（リロードなし）
@@ -43,6 +44,7 @@ test.describe("author mutations", () => {
     testAuthorName = `テスト著者-${String(Date.now())}`;
     await page.goto("/authors");
     await page.getByLabel("名前").fill(testAuthorName);
+    await page.getByLabel("読み仮名").fill("てすとちょしゃ");
     await page.getByRole("button", { name: "登録" }).click();
     await expect(
       page.locator("td").filter({ hasText: testAuthorName }),
@@ -57,12 +59,16 @@ test.describe("author mutations", () => {
     const nameInput = page.getByRole("textbox", { name: "名前" });
     await expect(nameInput).toHaveValue(testAuthorName);
     await nameInput.fill("デモ更新著者");
+    const yomiInput = page.getByRole("textbox", { name: "読み仮名" });
+    await expect(yomiInput).toHaveValue("てすとちょしゃ");
+    await yomiInput.fill("でもこうしんちょしゃ");
     await page.getByRole("button", { name: "Save" }).click();
 
     await expect(page).toHaveURL(/\/authors\/[^/]+$/);
     await expect(
       page.getByRole("heading", { name: "デモ更新著者" }),
     ).toBeVisible();
+    await expect(page.getByText("でもこうしんちょしゃ").first()).toBeVisible();
   });
 
   test("deletes author after confirmation", async ({ page }) => {

--- a/e2e-integration/authors.spec.ts
+++ b/e2e-integration/authors.spec.ts
@@ -2,7 +2,9 @@ import { expect, type Page } from "@playwright/test";
 import { test } from "./fixtures";
 
 const AUTHOR_NAME = "統合テスト著者";
+const AUTHOR_YOMI = "とうごうてすとちょしゃ";
 const UPDATED_AUTHOR_NAME = "更新された統合テスト著者";
+const UPDATED_AUTHOR_YOMI = "こうしんされたとうごうてすとちょしゃ";
 
 async function loginAndRegister(page: Page) {
   await page.goto("/books");
@@ -24,6 +26,7 @@ test.describe
       // Create author
       await page.goto("/authors");
       await page.getByLabel("名前").fill(AUTHOR_NAME);
+      await page.getByLabel("読み仮名").fill(AUTHOR_YOMI);
       await page.getByRole("button", { name: "登録" }).click();
       await expect(
         page.locator("td").filter({ hasText: AUTHOR_NAME }),
@@ -43,6 +46,9 @@ test.describe
       const nameInput = page.getByRole("textbox", { name: "名前" });
       await expect(nameInput).toHaveValue(AUTHOR_NAME);
       await nameInput.fill(UPDATED_AUTHOR_NAME);
+      const yomiInput = page.getByRole("textbox", { name: "読み仮名" });
+      await expect(yomiInput).toHaveValue(AUTHOR_YOMI);
+      await yomiInput.fill(UPDATED_AUTHOR_YOMI);
       await page.getByRole("button", { name: "Save" }).click();
 
       await expect(page).toHaveURL(/\/authors\/.+$/);
@@ -50,6 +56,7 @@ test.describe
       await expect(
         page.getByRole("heading", { name: UPDATED_AUTHOR_NAME }),
       ).toBeVisible();
+      await expect(page.getByText(UPDATED_AUTHOR_YOMI).first()).toBeVisible();
 
       // Delete the author
       await page.getByRole("button", { name: "削除" }).click();
@@ -71,6 +78,7 @@ test.describe
       // Create author
       await page.goto("/authors");
       await page.getByLabel("名前").fill(AUTHOR_NAME);
+      await page.getByLabel("読み仮名").fill(AUTHOR_YOMI);
       await page.getByRole("button", { name: "登録" }).click();
       await expect(
         page.locator("td").filter({ hasText: AUTHOR_NAME }),

--- a/e2e-integration/books.spec.ts
+++ b/e2e-integration/books.spec.ts
@@ -3,6 +3,7 @@ import { test } from "./fixtures";
 
 const BOOK_TITLE = "統合テスト書籍";
 const AUTHOR_NAME = "統合テスト著者";
+const AUTHOR_YOMI = "とうごうてすとちょしゃ";
 const UPDATED_TITLE = "更新された統合テスト書籍";
 
 async function loginAndRegister(page: Page) {
@@ -23,6 +24,7 @@ test.describe
       // Create author
       await page.goto("/authors");
       await page.getByLabel("名前").fill(AUTHOR_NAME);
+      await page.getByLabel("読み仮名").fill(AUTHOR_YOMI);
       await page.getByRole("button", { name: "登録" }).click();
       await expect(
         page.locator("td").filter({ hasText: AUTHOR_NAME }),
@@ -94,6 +96,7 @@ test.describe
       // Create author
       await page.goto("/authors");
       await page.getByLabel("名前").fill(AUTHOR_NAME);
+      await page.getByLabel("読み仮名").fill(AUTHOR_YOMI);
       await page.getByRole("button", { name: "登録" }).click();
       await expect(
         page.locator("td").filter({ hasText: AUTHOR_NAME }),
@@ -140,6 +143,7 @@ test.describe
       // Create author
       await page.goto("/authors");
       await page.getByLabel("名前").fill(AUTHOR_NAME);
+      await page.getByLabel("読み仮名").fill(AUTHOR_YOMI);
       await page.getByRole("button", { name: "登録" }).click();
 
       // Create a book

--- a/e2e-mock-api/authors.spec.ts
+++ b/e2e-mock-api/authors.spec.ts
@@ -111,7 +111,9 @@ test.describe("Authors UPDATE", () => {
     await expect(
       page.getByRole("heading", { name: "更新された著者" }),
     ).toBeVisible();
-    await expect(page.getByText("こうしんされたちょしゃ")).toBeVisible();
+    await expect(
+      page.getByText("こうしんされたちょしゃ").first(),
+    ).toBeVisible();
   });
 });
 

--- a/e2e-mock-api/authors.spec.ts
+++ b/e2e-mock-api/authors.spec.ts
@@ -12,6 +12,9 @@ test.describe("Authors READ", () => {
   test("displays author list", async ({ page }) => {
     await expect(page.locator("td").filter({ hasText: "著者1" })).toBeVisible();
     await expect(page.locator("td").filter({ hasText: "著者2" })).toBeVisible();
+    await expect(
+      page.locator("td").filter({ hasText: "ちょしゃいち" }),
+    ).toBeVisible();
   });
 
   test("search functionality works", async ({ page }) => {
@@ -23,6 +26,13 @@ test.describe("Authors READ", () => {
     await expect(
       page.locator("td").filter({ hasText: "著者2" }),
     ).not.toBeVisible();
+  });
+
+  test("searches authors by reading", async ({ page }) => {
+    const searchInput = page.getByPlaceholder("検索...");
+    await searchInput.fill("ちょしゃいち");
+    await expect(page.getByRole("link", { name: "著者1" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "著者2" })).not.toBeVisible();
   });
 
   test("navigates to author detail page", async ({ page }) => {
@@ -42,17 +52,23 @@ test.describe("Authors CREATE", () => {
 
   test("displays author creation form", async ({ page }) => {
     await expect(page.getByLabel("名前")).toBeVisible();
+    await expect(page.getByLabel("読み仮名")).toBeVisible();
     await expect(page.getByRole("button", { name: "登録" })).toBeVisible();
   });
 
   test("creates an author", async ({ page }) => {
     const newAuthorName = "新しい著者";
+    const newAuthorYomi = "あたらしいちょしゃ";
 
     await page.getByLabel("名前").fill(newAuthorName);
+    await page.getByLabel("読み仮名").fill(newAuthorYomi);
     await page.getByRole("button", { name: "登録" }).click();
 
     await expect(
       page.locator("td").filter({ hasText: newAuthorName }),
+    ).toBeVisible();
+    await expect(
+      page.locator("td").filter({ hasText: newAuthorYomi }),
     ).toBeVisible();
   });
 });
@@ -74,6 +90,9 @@ test.describe("Authors UPDATE", () => {
     await expect(page.getByRole("textbox", { name: "名前" })).toHaveValue(
       "著者1",
     );
+    await expect(page.getByRole("textbox", { name: "読み仮名" })).toHaveValue(
+      "ちょしゃいち",
+    );
   });
 
   test("updates author name", async ({ page }) => {
@@ -83,6 +102,8 @@ test.describe("Authors UPDATE", () => {
 
     const nameInput = page.getByRole("textbox", { name: "名前" });
     await nameInput.fill("更新された著者");
+    const yomiInput = page.getByRole("textbox", { name: "読み仮名" });
+    await yomiInput.fill("こうしんされたちょしゃ");
     await page.getByRole("button", { name: "Save" }).click();
 
     await expect(page).toHaveURL(/\/authors\/[^/]+$/);
@@ -90,6 +111,7 @@ test.describe("Authors UPDATE", () => {
     await expect(
       page.getByRole("heading", { name: "更新された著者" }),
     ).toBeVisible();
+    await expect(page.getByText("こうしんされたちょしゃ")).toBeVisible();
   });
 });
 

--- a/e2e-mock-api/mockStore.ts
+++ b/e2e-mock-api/mockStore.ts
@@ -33,6 +33,7 @@ type BookEventEntry = {
 type Author = {
   id: string;
   name: string;
+  yomi: string;
 };
 
 type Book = {
@@ -82,8 +83,8 @@ export class MockStore {
   }
 
   private seedData(): void {
-    const author1 = this.createAuthor("著者1");
-    const author2 = this.createAuthor("著者2");
+    const author1 = this.createAuthor("著者1", "ちょしゃいち");
+    const author2 = this.createAuthor("著者2", "ちょしゃに");
 
     this.createBook({
       title: "テスト書籍1",
@@ -198,10 +199,10 @@ export class MockStore {
     });
   }
 
-  private createAuthorInternal(name: string): Author {
+  private createAuthorInternal(name: string, yomi = ""): Author {
     const id = `author-${String(this.nextAuthorId)}`;
     this.nextAuthorId += 1;
-    const author: Author = { id, name };
+    const author: Author = { id, name, yomi };
     this.authors.set(id, author);
     return author;
   }
@@ -222,9 +223,16 @@ export class MockStore {
     return book;
   }
 
-  createAuthor(name: string): Author {
-    const author = this.createAuthorInternal(name);
-    this.recordAuthorEvent("CREATE", author.id, author.name, null, null, null);
+  createAuthor(name: string, yomi = ""): Author {
+    const author = this.createAuthorInternal(name, yomi);
+    this.recordAuthorEvent(
+      "CREATE",
+      author.id,
+      author.name,
+      author.yomi,
+      null,
+      null,
+    );
     return author;
   }
 
@@ -236,19 +244,19 @@ export class MockStore {
     return Array.from(this.authors.values());
   }
 
-  updateAuthor(id: string, name: string): Author | null {
+  updateAuthor(id: string, name: string, yomi = ""): Author | null {
     const author = this.authors.get(id);
     if (!author) return null;
-    const updated: Author = { id, name };
+    const updated: Author = { id, name, yomi };
     this.authors.set(id, updated);
-    this.recordAuthorEvent("UPDATE", id, name, null, null, null);
+    this.recordAuthorEvent("UPDATE", id, name, yomi, null, null);
     return updated;
   }
 
   deleteAuthor(id: string): boolean {
     const author = this.authors.get(id);
     if (!author) return false;
-    this.recordAuthorEvent("DELETE", id, author.name, null, null, null);
+    this.recordAuthorEvent("DELETE", id, author.name, author.yomi, null, null);
     const deleted = this.authors.delete(id);
     if (deleted) {
       this.books.forEach((book, bookId) => {

--- a/e2e-mock-api/resolvers.ts
+++ b/e2e-mock-api/resolvers.ts
@@ -20,13 +20,21 @@ export const createResolvers = (mockStore: MockStore) => ({
     },
     createAuthor: (
       _: unknown,
-      { authorData }: { authorData: { name: string } },
-    ) => ({ author: mockStore.createAuthor(authorData.name) }),
+      { authorData }: { authorData: { name: string; yomi?: string | null } },
+    ) => ({
+      author: mockStore.createAuthor(authorData.name, authorData.yomi ?? ""),
+    }),
     updateAuthor: (
       _: unknown,
-      { authorData }: { authorData: { id: string; name: string } },
+      {
+        authorData,
+      }: { authorData: { id: string; name: string; yomi?: string | null } },
     ) => {
-      const updated = mockStore.updateAuthor(authorData.id, authorData.name);
+      const updated = mockStore.updateAuthor(
+        authorData.id,
+        authorData.name,
+        authorData.yomi ?? "",
+      );
       if (!updated) {
         throw new Error(`Author not found: ${authorData.id}`);
       }

--- a/src/features/authors/AuthorDetailEdit.test.tsx
+++ b/src/features/authors/AuthorDetailEdit.test.tsx
@@ -68,7 +68,11 @@ beforeAll(() => {
   });
 });
 
-const testAuthor = { id: "author-1", name: "テスト著者" };
+const testAuthor = {
+  id: "author-1",
+  name: "テスト著者",
+  yomi: "てすとちょしゃ",
+};
 
 const createWrapper = (): React.FC<{ children: React.ReactNode }> => {
   const queryClient = new QueryClient({
@@ -88,12 +92,15 @@ describe("AuthorDetailEdit", () => {
     vi.mocked(showNotification).mockClear();
   });
 
-  test("renders name input with initial value", () => {
+  test("renders inputs with initial values", () => {
     render(<AuthorDetailEdit author={testAuthor} />, {
       wrapper: createWrapper(),
     });
     const input = screen.getByRole("textbox", { name: "名前" });
     expect(input).toHaveValue("テスト著者");
+    expect(screen.getByRole("textbox", { name: "読み仮名" })).toHaveValue(
+      "てすとちょしゃ",
+    );
   });
 
   test("renders Save and Cancel buttons", () => {
@@ -104,18 +111,22 @@ describe("AuthorDetailEdit", () => {
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
   });
 
-  test("calls updateAuthor mutation with updated name on save", async () => {
+  test("calls updateAuthor mutation with updated values on save", async () => {
     render(<AuthorDetailEdit author={testAuthor} />, {
       wrapper: createWrapper(),
     });
     const input = screen.getByRole("textbox", { name: "名前" });
     await userEvent.clear(input);
     await userEvent.type(input, "更新された著者");
+    const yomiInput = screen.getByRole("textbox", { name: "読み仮名" });
+    await userEvent.clear(yomiInput);
+    await userEvent.type(yomiInput, "こうしんされたちょしゃ");
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
     await waitFor(() => {
       expect(mockMutateAsync).toHaveBeenCalledWith({
         id: "author-1",
         name: "更新された著者",
+        yomi: "こうしんされたちょしゃ",
       });
     });
   });

--- a/src/features/authors/AuthorDetailEdit.test.tsx
+++ b/src/features/authors/AuthorDetailEdit.test.tsx
@@ -146,6 +146,21 @@ describe("AuthorDetailEdit", () => {
     ).toBeInTheDocument();
   });
 
+  test("shows validation error when reading is empty", async () => {
+    render(<AuthorDetailEdit author={testAuthor} />, {
+      wrapper: createWrapper(),
+    });
+    const input = screen.getByRole("textbox", { name: "読み仮名" });
+    await userEvent.clear(input);
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => {
+      expect(mockMutateAsync).not.toHaveBeenCalled();
+    });
+    expect(
+      await screen.findByText("読み仮名を入力してください"),
+    ).toBeInTheDocument();
+  });
+
   test("shows error notification when update fails", async () => {
     mockMutateAsync.mockRejectedValueOnce(new Error("Network error"));
     render(<AuthorDetailEdit author={testAuthor} />, {

--- a/src/features/authors/AuthorDetailEdit.tsx
+++ b/src/features/authors/AuthorDetailEdit.tsx
@@ -11,6 +11,7 @@ import { authorFormSchema, type AuthorFormValues } from "./authorFormSchema";
 type Author = {
   id: string;
   name: string;
+  yomi: string;
 };
 
 export const AuthorDetailEdit: React.FC<{ author: Author }> = ({ author }) => {
@@ -18,7 +19,7 @@ export const AuthorDetailEdit: React.FC<{ author: Author }> = ({ author }) => {
   const updateAuthorMutation = useUpdateAuthor();
 
   const form = useForm<AuthorFormValues>({
-    initialValues: { name: author.name },
+    initialValues: { name: author.name, yomi: author.yomi },
     validate: zod4Resolver(authorFormSchema),
     validateInputOnBlur: true,
   });
@@ -28,6 +29,7 @@ export const AuthorDetailEdit: React.FC<{ author: Author }> = ({ author }) => {
       await updateAuthorMutation.mutateAsync({
         id: author.id,
         name: values.name,
+        yomi: values.yomi,
       });
       await navigate({ to: "/authors/$id", params: { id: author.id } });
       showNotification({ message: "更新しました", color: "teal" });
@@ -49,6 +51,7 @@ export const AuthorDetailEdit: React.FC<{ author: Author }> = ({ author }) => {
         style={{ minWidth: 400 }}
       >
         <TextInput label="名前" {...form.getInputProps("name")} />
+        <TextInput label="読み仮名" {...form.getInputProps("yomi")} />
         <Group mt="md">
           <Button type="submit">Save</Button>
           <LinkButton

--- a/src/features/authors/AuthorDetailShow.test.tsx
+++ b/src/features/authors/AuthorDetailShow.test.tsx
@@ -71,7 +71,11 @@ beforeAll(() => {
   });
 });
 
-const testAuthor = { id: "author-1", name: "テスト著者" };
+const testAuthor = {
+  id: "author-1",
+  name: "テスト著者",
+  yomi: "てすとちょしゃ",
+};
 
 const createWrapper = (): React.FC<{ children: React.ReactNode }> => {
   const queryClient = new QueryClient({
@@ -97,6 +101,7 @@ describe("AuthorDetailShow", () => {
     expect(
       screen.getByRole("heading", { name: "テスト著者" }),
     ).toBeInTheDocument();
+    expect(screen.getByText("てすとちょしゃ")).toBeInTheDocument();
   });
 
   test("renders edit and delete buttons", () => {

--- a/src/features/authors/AuthorDetailShow.tsx
+++ b/src/features/authors/AuthorDetailShow.tsx
@@ -18,6 +18,7 @@ import { LinkButton } from "../../compoments/mantineTsr";
 type Author = {
   id: string;
   name: string;
+  yomi: string;
 };
 
 const DeleteButton: React.FC<{ author: Author }> = ({ author }) => {
@@ -103,6 +104,10 @@ export const AuthorDetailShow: React.FC<{ author: Author }> = ({ author }) => {
         <Box>
           <Text fw="bold">名前</Text>
           <Text>{author.name}</Text>
+        </Box>
+        <Box>
+          <Text fw="bold">読み仮名</Text>
+          <Text>{author.yomi}</Text>
         </Box>
       </Stack>
       <Group m={20}>

--- a/src/features/authors/AuthorLoader.tsx
+++ b/src/features/authors/AuthorLoader.tsx
@@ -2,7 +2,7 @@ import { Center, Loader, Text } from "@mantine/core";
 import React from "react";
 import { useAuthor } from "../../compoments/hooks/useAuthor";
 
-type Author = { id: string; name: string };
+type Author = { id: string; name: string; yomi: string };
 
 type AuthorLoaderProps = {
   id: string;

--- a/src/features/authors/authorFormSchema.ts
+++ b/src/features/authors/authorFormSchema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const authorFormSchema = z.object({
   name: z.string().trim().min(1, { error: "Please enter a valid name" }),
-  yomi: z.string().trim(),
+  yomi: z.string().trim().min(1, { error: "読み仮名を入力してください" }),
 });
 
 export type AuthorFormValues = z.infer<typeof authorFormSchema>;

--- a/src/features/authors/authorFormSchema.ts
+++ b/src/features/authors/authorFormSchema.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const authorFormSchema = z.object({
   name: z.string().trim().min(1, { error: "Please enter a valid name" }),
+  yomi: z.string().trim(),
 });
 
 export type AuthorFormValues = z.infer<typeof authorFormSchema>;

--- a/src/features/books/entity/Author.ts
+++ b/src/features/books/entity/Author.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const authorSchema = z.object({
   id: z.string(),
   name: z.string(),
+  yomi: z.string().optional(),
 });
 
 export type Author = z.infer<typeof authorSchema>;

--- a/src/graphql/author.graphql
+++ b/src/graphql/author.graphql
@@ -2,5 +2,6 @@ query author($authorId: ID!) {
   author(id: $authorId) {
     id
     name
+    yomi
   }
 }

--- a/src/graphql/authors.graphql
+++ b/src/graphql/authors.graphql
@@ -2,5 +2,6 @@ query authors {
   authors {
     id
     name
+    yomi
   }
 }

--- a/src/graphql/updateAuthor.graphql
+++ b/src/graphql/updateAuthor.graphql
@@ -3,6 +3,7 @@ mutation updateAuthor($authorData: UpdateAuthorInput!) {
     author {
       id
       name
+      yomi
     }
   }
 }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -246,7 +246,10 @@ export const handlers = [
         { status: 200 },
       );
     }
-    const author = mockStore.createAuthor(variables.authorData.name);
+    const yomi = isString(variables.authorData.yomi)
+      ? variables.authorData.yomi
+      : "";
+    const author = mockStore.createAuthor(variables.authorData.name, yomi);
     return HttpResponse.json({
       data: {
         createAuthor: {
@@ -273,7 +276,8 @@ export const handlers = [
         { status: 200 },
       );
     }
-    const author = mockStore.updateAuthor(authorData.id, authorData.name);
+    const yomi = isString(authorData.yomi) ? authorData.yomi : "";
+    const author = mockStore.updateAuthor(authorData.id, authorData.name, yomi);
     if (!author) {
       return HttpResponse.json(
         { errors: [{ message: `Author not found: ${authorData.id}` }] },

--- a/src/mocks/mockStore.ts
+++ b/src/mocks/mockStore.ts
@@ -1,6 +1,7 @@
 type Author = {
   id: string;
   name: string;
+  yomi: string;
 };
 
 type Book = {
@@ -42,8 +43,8 @@ class MockStore {
   }
 
   private seedData(): void {
-    const author1 = this.createAuthor("著者1");
-    const author2 = this.createAuthor("著者2");
+    const author1 = this.createAuthor("著者1", "ちょしゃいち");
+    const author2 = this.createAuthor("著者2", "ちょしゃに");
 
     this.createBook({
       title: "テスト書籍1",
@@ -68,10 +69,10 @@ class MockStore {
     });
   }
 
-  createAuthor(name: string): Author {
+  createAuthor(name: string, yomi = ""): Author {
     const id = `author-${String(this.nextAuthorId)}`;
     this.nextAuthorId += 1;
-    const author: Author = { id, name };
+    const author: Author = { id, name, yomi };
     this.authors.set(id, author);
     return author;
   }
@@ -84,10 +85,10 @@ class MockStore {
     return Array.from(this.authors.values());
   }
 
-  updateAuthor(id: string, name: string): Author | null {
+  updateAuthor(id: string, name: string, yomi = ""): Author | null {
     const author = this.authors.get(id);
     if (!author) return null;
-    const updated: Author = { id, name };
+    const updated: Author = { id, name, yomi };
     this.authors.set(id, updated);
     return updated;
   }

--- a/src/routes/authors/index.tsx
+++ b/src/routes/authors/index.tsx
@@ -9,6 +9,7 @@ import {
 } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { createFileRoute } from "@tanstack/react-router";
+import { zod4Resolver } from "mantine-form-zod-resolver";
 import {
   ColumnDef,
   createColumnHelper,
@@ -22,6 +23,10 @@ import { useState } from "react";
 import { useCreateAuthor } from "../../compoments/hooks/useCreateAuthor";
 import { useAuthors } from "../../compoments/hooks/useAuthors";
 import { Link } from "../../compoments/mantineTsr";
+import {
+  authorFormSchema,
+  type AuthorFormValues,
+} from "../../features/authors/authorFormSchema";
 import type { Author } from "../../features/books/entity/Author";
 
 export const Route = createFileRoute("/authors/")({
@@ -32,17 +37,13 @@ function RouteComponent() {
   return <AuthorIndexPage />;
 }
 
-type RegisterAuthorFormInput = {
-  name: string;
-  yomi: string;
-};
-
 const RegisterAuthorForm: React.FC = () => {
   const createAuthorMutation = useCreateAuthor();
-  const form = useForm<RegisterAuthorFormInput>({
+  const form = useForm<AuthorFormValues>({
     initialValues: { name: "", yomi: "" },
+    validate: zod4Resolver(authorFormSchema),
   });
-  const handleSubmit = (data: RegisterAuthorFormInput) => {
+  const handleSubmit = (data: AuthorFormValues) => {
     if (createAuthorMutation.isPending) return;
     createAuthorMutation.mutate({ name: data.name, yomi: data.yomi });
   };

--- a/src/routes/authors/index.tsx
+++ b/src/routes/authors/index.tsx
@@ -34,21 +34,23 @@ function RouteComponent() {
 
 type RegisterAuthorFormInput = {
   name: string;
+  yomi: string;
 };
 
 const RegisterAuthorForm: React.FC = () => {
   const createAuthorMutation = useCreateAuthor();
   const form = useForm<RegisterAuthorFormInput>({
-    initialValues: { name: "" },
+    initialValues: { name: "", yomi: "" },
   });
   const handleSubmit = (data: RegisterAuthorFormInput) => {
     if (createAuthorMutation.isPending) return;
-    createAuthorMutation.mutate({ name: data.name });
+    createAuthorMutation.mutate({ name: data.name, yomi: data.yomi });
   };
 
   return (
     <form onSubmit={form.onSubmit(handleSubmit)}>
       <TextInput label="名前" {...form.getInputProps("name")} />
+      <TextInput label="読み仮名" {...form.getInputProps("yomi")} />
       <Button
         type="submit"
         mt="md"
@@ -73,6 +75,9 @@ const AuthorIndexPage: React.FC = () => {
           {row.getValue("name")}
         </Link>
       ),
+    }),
+    columnHelper.accessor("yomi", {
+      header: "読み仮名",
     }),
   ];
   const table = useReactTable({


### PR DESCRIPTION
## Summary

- fetch the author `yomi` field from the GraphQL API
- support author reading input in create and edit flows
- display and search author readings in the author list and detail page
- keep browser and Playwright mock stores aligned with the API

## Why

The API now exposes author readings, but the frontend only requested and used author names. This change wires the existing field through the UI and local test infrastructure.

## Impact

Users can register and update author readings, see them in author views, and find authors by reading.

## Validation

- `pnpm run generate`
- `pnpm run lint:fix`
- `pnpm run typecheck`
- unit tests: 95 passed (also verified after formatting in three low-memory shards: 34 + 36 + 25)
- focused author component tests: 10 passed

The mock API E2E suite could not launch Chromium in the local environment because `libnspr4.so` is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 著者に「読み仮名」を登録・編集できるようになりました。
  * 著者一覧に読み仮名が表示されます。
  * 著者詳細画面で読み仮名を確認できます。
  * 著者の検索で読み仮名を利用できるようになりました。
  * 著者の作成・更新時に、読み仮名も保存されます。

* **テスト**
  * 読み仮名の表示、検索、登録、編集に関する確認を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->