### PR TITLE
Show author readings on book views

### DIFF
--- a/e2e-demo-mode/books.spec.ts
+++ b/e2e-demo-mode/books.spec.ts
@@ -7,6 +7,21 @@ test("displays book list", async ({ page }) => {
   await expect(page.getByRole("link", { name: "著者" })).toBeVisible();
   await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
   await expect(page.getByRole("link", { name: "テスト書籍2" })).toBeVisible();
+  await expect(
+    page.getByRole("columnheader", { name: "著者読み仮名" }),
+  ).toBeVisible();
+  const firstBookRow = page
+    .getByRole("link", { name: "テスト書籍1" })
+    .locator("xpath=ancestor::tr");
+  await expect(firstBookRow.getByText("ちょしゃいち")).toBeVisible();
+
+  await page.getByRole("link", { name: "テスト書籍1" }).click();
+  await expect(
+    page.getByTestId("book-detail").getByText("著者読み仮名"),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("book-detail").getByText("ちょしゃいち"),
+  ).toBeVisible();
 });
 
 test("creates book and displays in list", async ({ page }) => {

--- a/e2e-integration/books.spec.ts
+++ b/e2e-integration/books.spec.ts
@@ -55,12 +55,22 @@ test.describe
         page.getByRole("dialog", { name: "書籍追加" }),
       ).not.toBeVisible();
       await expect(page.getByRole("link", { name: BOOK_TITLE })).toBeVisible();
+      const bookRow = page
+        .getByRole("link", { name: BOOK_TITLE })
+        .locator("xpath=ancestor::tr");
+      await expect(bookRow.getByText(AUTHOR_YOMI)).toBeVisible();
 
       // Navigate to detail page
       await page.getByRole("link", { name: BOOK_TITLE }).click();
       await expect(page).toHaveURL(/\/books\/.+$/);
       await expect(
         page.getByTestId("book-detail").getByText(BOOK_TITLE),
+      ).toBeVisible();
+      await expect(
+        page.getByTestId("book-detail").getByText("著者読み仮名"),
+      ).toBeVisible();
+      await expect(
+        page.getByTestId("book-detail").getByText(AUTHOR_YOMI),
       ).toBeVisible();
 
       // Update the book

--- a/e2e-mock-api/books.spec.ts
+++ b/e2e-mock-api/books.spec.ts
@@ -18,6 +18,13 @@ test.describe("Books READ", () => {
   });
 
   test("displays book list", async ({ page }) => {
+    await expect(
+      page.getByRole("columnheader", { name: "著者読み仮名" }),
+    ).toBeVisible();
+    const firstBookRow = page
+      .getByRole("link", { name: "テスト書籍1" })
+      .locator("xpath=ancestor::tr");
+    await expect(firstBookRow.getByText("ちょしゃいち")).toBeVisible();
     await expect(page.getByRole("link", { name: "テスト書籍1" })).toBeVisible();
     await expect(page.getByRole("link", { name: "テスト書籍2" })).toBeVisible();
   });
@@ -38,6 +45,12 @@ test.describe("Books READ", () => {
     ).toBeVisible();
     await expect(
       page.getByTestId("book-detail").getByText("978-4-00-000001-0"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("book-detail").getByText("著者読み仮名"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("book-detail").getByText("ちょしゃいち"),
     ).toBeVisible();
 
     await expect(page.getByRole("link", { name: "Back" })).toBeVisible();

--- a/src/features/books/AuthorsCombobox.test.tsx
+++ b/src/features/books/AuthorsCombobox.test.tsx
@@ -5,11 +5,12 @@ import userEvent from "@testing-library/user-event";
 import React, { useState } from "react";
 import { type Mock, vi } from "vitest";
 import { AuthorsCombobox } from "./AuthorsCombobox";
+import type { BookFormAuthor } from "./bookFormSchema";
 import type { Author } from "./entity/Author";
 
 const defaultAuthors: Author[] = [
-  { id: "1", name: "name1" },
-  { id: "2", name: "name2" },
+  { id: "1", name: "name1", yomi: "name one" },
+  { id: "2", name: "name2", yomi: "name two" },
 ];
 
 beforeAll(() => {
@@ -50,7 +51,7 @@ const mockMatchMedia = () => {
 
 type TestComboboxProps = {
   onChange: Mock;
-  initial?: Author[];
+  initial?: BookFormAuthor[];
   authors?: Author[];
   error?: React.ReactNode;
 };

--- a/src/features/books/AuthorsCombobox.tsx
+++ b/src/features/books/AuthorsCombobox.tsx
@@ -9,12 +9,13 @@ import {
   useCombobox,
 } from "@mantine/core";
 import React, { useRef, useState } from "react";
+import type { BookFormAuthor } from "./bookFormSchema";
 import { Author } from "./entity/Author";
 
 type AuthorsComboboxProps = {
   authors: Author[];
-  value: Author[];
-  onChange: (authors: Author[]) => void;
+  value: BookFormAuthor[];
+  onChange: (authors: BookFormAuthor[]) => void;
   error?: React.ReactNode;
 };
 
@@ -60,7 +61,7 @@ export const AuthorsCombobox: React.FC<AuthorsComboboxProps> = ({
       } else {
         const author = authors.find((a) => a.id === val);
         if (author) {
-          onChange([...value, author]);
+          onChange([...value, { id: author.id, name: author.name }]);
         }
       }
     }
@@ -70,7 +71,7 @@ export const AuthorsCombobox: React.FC<AuthorsComboboxProps> = ({
     onChange(value.filter((a) => a.id !== id));
   };
 
-  const handlePendingAuthorEdit = (author: Author) => {
+  const handlePendingAuthorEdit = (author: BookFormAuthor) => {
     setEditingAuthorId(author.id);
     setEditingName(author.name);
   };

--- a/src/features/books/BookDetailShow.test.tsx
+++ b/src/features/books/BookDetailShow.test.tsx
@@ -1,0 +1,72 @@
+import "@testing-library/jest-dom";
+import { MantineProvider } from "@mantine/core";
+import { render, screen, within } from "@testing-library/react";
+import React from "react";
+import { vi } from "vitest";
+import { BookDetailShow } from "./BookDetailShow";
+import type { Book } from "./entity/Book";
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@tanstack/react-router")>();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+vi.mock("../../compoments/hooks/useDeleteBook", () => ({
+  useDeleteBook: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock("../../compoments/mantineTsr", () => ({
+  LinkButton: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
+const book: Book = {
+  id: "book-1",
+  title: "テスト書籍",
+  authors: [
+    { id: "author-1", name: "山田太郎", yomi: "やまだたろう" },
+    { id: "author-2", name: "鈴木花子", yomi: "すずきはなこ" },
+  ],
+  isbn: "978-4-00-000001-0",
+  read: false,
+  owned: true,
+  priority: 50,
+  format: "PRINTED",
+  store: "UNKNOWN",
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+};
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+test("shows authors and author readings as separate items", () => {
+  render(<BookDetailShow book={book} />, {
+    wrapper: ({ children }) => (
+      <MantineProvider env="test">{children}</MantineProvider>
+    ),
+  });
+
+  const detail = screen.getByTestId("book-detail");
+  expect(within(detail).getByText("著者")).toBeInTheDocument();
+  expect(within(detail).getByText("山田太郎, 鈴木花子")).toBeInTheDocument();
+  expect(within(detail).getByText("著者読み仮名")).toBeInTheDocument();
+  expect(
+    within(detail).getByText("やまだたろう, すずきはなこ"),
+  ).toBeInTheDocument();
+});

--- a/src/features/books/BookDetailShow.tsx
+++ b/src/features/books/BookDetailShow.tsx
@@ -20,6 +20,7 @@ import { useDeleteBook } from "../../compoments/hooks/useDeleteBook";
 import { Book } from "./entity/Book";
 import { displayBookFormat } from "./entity/BookFormat";
 import { displayBookStore } from "./entity/BookStore";
+import { displayAuthorYomis } from "./displayAuthorYomis";
 
 const BookDetailShowItem: React.FC<{
   field: string;
@@ -129,6 +130,10 @@ export const BookDetailShow: React.FC<{ book: Book }> = (props) => {
         <BookDetailShowItem
           field="著者"
           value={book.authors.map((author) => author.name).join(", ")}
+        />
+        <BookDetailShowItem
+          field="著者読み仮名"
+          value={displayAuthorYomis(book.authors)}
         />
         <BookDetailShowItem
           field="形式"

--- a/src/features/books/BookHistory.test.tsx
+++ b/src/features/books/BookHistory.test.tsx
@@ -54,8 +54,8 @@ const createWrapper = (): React.FC<{ children: React.ReactNode }> => {
 };
 
 const mockAuthors = [
-  { id: "author-1", name: "著者1" },
-  { id: "author-2", name: "著者2" },
+  { id: "author-1", name: "著者1", yomi: "ちょしゃいち" },
+  { id: "author-2", name: "著者2", yomi: "ちょしゃに" },
 ];
 
 const mockEvents = {

--- a/src/features/books/BookList.test.tsx
+++ b/src/features/books/BookList.test.tsx
@@ -76,7 +76,7 @@ const testBooks: Book[] = [
   {
     id: "book-1",
     title: "テスト書籍1",
-    authors: [{ id: "author-1", name: "著者1" }],
+    authors: [{ id: "author-1", name: "著者1", yomi: "ちょしゃいち" }],
     isbn: "978-4-00-000001-0",
     read: false,
     owned: true,
@@ -89,7 +89,7 @@ const testBooks: Book[] = [
   {
     id: "book-2",
     title: "テスト書籍2",
-    authors: [{ id: "author-2", name: "著者2" }],
+    authors: [{ id: "author-2", name: "著者2", yomi: "ちょしゃに" }],
     isbn: "978-4-00-000002-7",
     read: true,
     owned: true,
@@ -102,7 +102,7 @@ const testBooks: Book[] = [
   {
     id: "book-3",
     title: "テスト書籍3",
-    authors: [{ id: "author-1", name: "著者1" }],
+    authors: [{ id: "author-1", name: "著者1", yomi: "ちょしゃいち" }],
     isbn: "978-4-00-000003-4",
     read: false,
     owned: false,
@@ -115,7 +115,7 @@ const testBooks: Book[] = [
   {
     id: "book-4",
     title: "テスト書籍4",
-    authors: [{ id: "author-2", name: "著者2" }],
+    authors: [{ id: "author-2", name: "著者2", yomi: "ちょしゃに" }],
     isbn: "978-4-00-000004-1",
     read: true,
     owned: false,
@@ -155,6 +155,16 @@ describe("BookList filters", () => {
     expect(screen.getByText("テスト書籍2")).toBeInTheDocument();
     expect(screen.getByText("テスト書籍3")).toBeInTheDocument();
     expect(screen.getByText("テスト書籍4")).toBeInTheDocument();
+  });
+
+  test("shows author readings in an independent column", () => {
+    renderBookList();
+
+    expect(
+      screen.getByRole("columnheader", { name: "著者読み仮名" }),
+    ).toBeInTheDocument();
+    const row = screen.getByRole("row", { name: /テスト書籍1/ });
+    expect(within(row).getByText("ちょしゃいち")).toBeInTheDocument();
   });
 
   test("title string filter shows only matching books", async () => {

--- a/src/features/books/BookList.test.tsx
+++ b/src/features/books/BookList.test.tsx
@@ -12,6 +12,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { vi } from "vitest";
+import { useAuthors } from "../../compoments/hooks/useAuthors";
 import { BookList } from "./BookList";
 import type { Book } from "./entity/Book";
 
@@ -27,18 +28,18 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
   };
 });
 
-vi.mock("../../compoments/hooks/useAuthors", () => ({
-  useAuthors: () => ({
-    data: {
-      authors: [
-        { id: "author-1", name: "著者1" },
-        { id: "author-2", name: "著者2" },
-      ],
-    },
-    isLoading: false,
-    error: null,
-  }),
-}));
+vi.mock(import("../../compoments/hooks/useAuthors"));
+
+vi.mocked(useAuthors, { partial: true }).mockReturnValue({
+  data: {
+    authors: [
+      { id: "author-1", name: "著者1", yomi: "ちょしゃいち" },
+      { id: "author-2", name: "著者2", yomi: "ちょしゃに" },
+    ],
+  },
+  isLoading: false,
+  error: null,
+});
 
 vi.mock("../../compoments/mantineTsr", () => ({
   Link: ({ children }: { children: React.ReactNode }) => (

--- a/src/features/books/BookList.tsx
+++ b/src/features/books/BookList.tsx
@@ -45,6 +45,7 @@ import { Book } from "./entity/Book";
 import { displayBookFormat } from "./entity/BookFormat";
 import { displayBookStore } from "./entity/BookStore";
 import { Filter } from "./Filter";
+import { displayAuthorYomis } from "./displayAuthorYomis";
 
 type FilterType = "string" | "boolean" | "store" | "format" | "authors";
 
@@ -100,6 +101,12 @@ const columns: ColumnDef<Book>[] = [
         .join(", "),
     meta: { filterType: "authors" },
     filterFn: authorsFilter,
+    minSize: 200,
+  }),
+  columnHelper.display({
+    id: "authorYomis",
+    header: "著者読み仮名",
+    cell: (info) => displayAuthorYomis(info.row.original.authors),
     minSize: 200,
   }),
   columnHelper.accessor("isbn", {

--- a/src/features/books/bookFormSchema.ts
+++ b/src/features/books/bookFormSchema.ts
@@ -2,9 +2,19 @@ import { z } from "zod";
 import { BOOK_FORMAT_VALUE } from "./entity/BookFormat";
 import { BOOK_STORE_VALUE } from "./entity/BookStore";
 
+export type BookFormAuthor = {
+  id: string;
+  name: string;
+};
+
+export const bookFormAuthorSchema: z.ZodType<BookFormAuthor> = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
 export const bookFormSchema = z.object({
   title: z.string().min(1),
-  authors: z.array(z.object({ id: z.string(), name: z.string() })).min(1),
+  authors: z.array(bookFormAuthorSchema).min(1),
   isbn: z.string().regex(/(^$|^(\d-?){12}\d$)/),
   read: z.boolean().default(false),
   priority: z.number().int().min(0).max(100).default(50),

--- a/src/features/books/displayAuthorYomis.test.ts
+++ b/src/features/books/displayAuthorYomis.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+import { displayAuthorYomis } from "./displayAuthorYomis";
+
+describe("displayAuthorYomis", () => {
+  test("displays a single author reading", () => {
+    expect(displayAuthorYomis([{ yomi: "やまだたろう" }])).toBe("やまだたろう");
+  });
+
+  test("displays multiple author readings in order", () => {
+    expect(
+      displayAuthorYomis([{ yomi: "やまだたろう" }, { yomi: "すずきはなこ" }]),
+    ).toBe("やまだたろう, すずきはなこ");
+  });
+
+  test("displays missing readings as hyphens", () => {
+    expect(
+      displayAuthorYomis([
+        { yomi: "やまだたろう" },
+        { yomi: null },
+        { yomi: undefined },
+        { yomi: "" },
+      ]),
+    ).toBe("やまだたろう, -, -, -");
+  });
+
+  test("displays an empty string when there are no authors", () => {
+    expect(displayAuthorYomis([])).toBe("");
+  });
+});

--- a/src/features/books/displayAuthorYomis.test.ts
+++ b/src/features/books/displayAuthorYomis.test.ts
@@ -12,15 +12,10 @@ describe("displayAuthorYomis", () => {
     ).toBe("やまだたろう, すずきはなこ");
   });
 
-  test("displays missing readings as hyphens", () => {
-    expect(
-      displayAuthorYomis([
-        { yomi: "やまだたろう" },
-        { yomi: null },
-        { yomi: undefined },
-        { yomi: "" },
-      ]),
-    ).toBe("やまだたろう, -, -, -");
+  test("displays empty readings as hyphens", () => {
+    expect(displayAuthorYomis([{ yomi: "やまだたろう" }, { yomi: "" }])).toBe(
+      "やまだたろう, -",
+    );
   });
 
   test("displays an empty string when there are no authors", () => {

--- a/src/features/books/displayAuthorYomis.ts
+++ b/src/features/books/displayAuthorYomis.ts
@@ -1,6 +1,4 @@
-type AuthorWithYomi = {
-  yomi: string;
-};
+import type { Author } from "./entity/Author";
 
-export const displayAuthorYomis = (authors: AuthorWithYomi[]): string =>
-  authors.map((author) => (author.yomi.length ? author.yomi : "-")).join(", ");
+export const displayAuthorYomis = (authors: Pick<Author, "yomi">[]): string =>
+  authors.map((author) => (author.yomi === "" ? "-" : author.yomi)).join(", ");

--- a/src/features/books/displayAuthorYomis.ts
+++ b/src/features/books/displayAuthorYomis.ts
@@ -1,6 +1,6 @@
 type AuthorWithYomi = {
-  yomi?: string | null;
+  yomi: string;
 };
 
 export const displayAuthorYomis = (authors: AuthorWithYomi[]): string =>
-  authors.map((author) => (author.yomi?.length ? author.yomi : "-")).join(", ");
+  authors.map((author) => (author.yomi.length ? author.yomi : "-")).join(", ");

--- a/src/features/books/displayAuthorYomis.ts
+++ b/src/features/books/displayAuthorYomis.ts
@@ -1,0 +1,6 @@
+type AuthorWithYomi = {
+  yomi?: string | null;
+};
+
+export const displayAuthorYomis = (authors: AuthorWithYomi[]): string =>
+  authors.map((author) => (author.yomi?.length ? author.yomi : "-")).join(", ");

--- a/src/features/books/entity/Author.ts
+++ b/src/features/books/entity/Author.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const authorSchema = z.object({
   id: z.string(),
   name: z.string(),
-  yomi: z.string().optional(),
+  yomi: z.string(),
 });
 
 export type Author = z.infer<typeof authorSchema>;

--- a/src/features/books/entity/Book.test.ts
+++ b/src/features/books/entity/Book.test.ts
@@ -3,7 +3,7 @@ import { graphQlBookToBook } from "./Book";
 const baseGraphQLBook = {
   id: "book-1",
   title: "Test Book",
-  authors: [{ id: "author-1", name: "Author One" }],
+  authors: [{ id: "author-1", name: "Author One", yomi: "author one" }],
   isbn: "9784000000001",
   read: false,
   owned: true,
@@ -35,7 +35,9 @@ describe("graphQlBookToBook", () => {
     const book = graphQlBookToBook(baseGraphQLBook);
     expect(book.id).toBe("book-1");
     expect(book.title).toBe("Test Book");
-    expect(book.authors).toEqual([{ id: "author-1", name: "Author One" }]);
+    expect(book.authors).toEqual([
+      { id: "author-1", name: "Author One", yomi: "author one" },
+    ]);
     expect(book.isbn).toBe("9784000000001");
     expect(book.read).toBe(false);
     expect(book.owned).toBe(true);

--- a/src/features/books/resolvePendingAuthors.ts
+++ b/src/features/books/resolvePendingAuthors.ts
@@ -1,9 +1,9 @@
-import type { Author } from "./entity/Author";
+import type { BookFormAuthor } from "./bookFormSchema";
 
 export const resolvePendingAuthors = async (
-  authors: Author[],
+  authors: BookFormAuthor[],
   createAuthor: (name: string) => Promise<string>,
-): Promise<Author[]> => {
+): Promise<BookFormAuthor[]> => {
   const pendingNames = new Set(
     authors.filter((a) => a.id.startsWith("__pending__:")).map((a) => a.name),
   );

--- a/src/graphql/book.graphql
+++ b/src/graphql/book.graphql
@@ -5,6 +5,7 @@ query book($bookId: ID!) {
     authors {
       id
       name
+      yomi
     }
     isbn
     read

--- a/src/graphql/books.graphql
+++ b/src/graphql/books.graphql
@@ -5,6 +5,7 @@ query books {
     authors {
       id
       name
+      yomi
     }
     isbn
     read


### PR DESCRIPTION
## Summary

- fetch each book author's `yomi` in the list and detail queries
- show author readings in an independent `著者読み仮名` column and detail field
- preserve author order and display an empty reading as `-`
- keep API authors strict with required `yomi: string`
- separate the form-only `BookFormAuthor` shape from complete API authors

## Tests

- add unit coverage for single and multiple readings, empty readings, and books without authors
- verify independent author and author-reading presentation in list and detail component tests
- verify list and detail presentation in mock API and demo-mode E2E suites
- extend the existing real API CRUD scenario to verify the created author's reading without adding extra setup or cleanup

## Validation

- `pnpm run generate` — passed
- `pnpm run lint:fix` — passed
- `TZ=UTC pnpm run test` — 102 passed
- `pnpm run typecheck` — passed
- `pnpm run test:e2e:demo-mode` — 11 passed before the type-only refactor; the 5 book tests also passed afterward with one worker
- `pnpm run test:e2e:mock-api` — 43 passed before the type refactor; subsequent parallel runs had unrelated login/render timeouts, while 22 of 23 book tests passed with one worker and the remaining existing store-select test was flaky
- `pnpm run test:integration` — not run because Docker is unavailable in the WSL environment; `pnpm run integration:up` failed before starting services


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 書籍一覧に「著者読み仮名」カラムを追加しました。
  * 書籍詳細画面に著者の読み仮名を表示するようになりました。
  * 複数著者の読み仮名を順番に表示し、未登録の場合は「-」で表示します。
  * 著者読み仮名の情報を取得・保持できるようになりました。

* **テスト**
  * 書籍一覧・詳細画面での著者読み仮名表示を確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->