### PR TITLE
Enforce strict boolean expressions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,9 @@
 - Follow existing conventions in the codebase
 - Use existing libraries and utilities
 - Never introduce code that exposes or logs secrets
+- Prefer `value == null` and `value != null` for nullish checks when `null`
+  and `undefined` do not need to be distinguished. Use strict equality only
+  when the distinction is meaningful.
 - When ignoring a linter or security tool finding, always add a comment
   explaining why it is safe to ignore. Place the comment on the line immediately
   before the ignore directive.

--- a/e2e-integration/fixtures.ts
+++ b/e2e-integration/fixtures.ts
@@ -62,7 +62,12 @@ export const test = base.extend<Record<never, never>>({
         const nonce = url.searchParams.get("nonce") ?? "";
         const responseMode = url.searchParams.get("response_mode");
 
-        if (!redirectUri || !state) {
+        if (
+          redirectUri === null ||
+          redirectUri === "" ||
+          state === null ||
+          state === ""
+        ) {
           await route.abort();
           return;
         }
@@ -113,7 +118,7 @@ window.parent.postMessage({
       `https://${TEST_AUTH0_DOMAIN}/oauth/token`,
       async (route) => {
         const body = route.request().postData();
-        if (!body) {
+        if (body === null || body === "") {
           await route.abort();
           return;
         }

--- a/e2e-mock-api/fixtures.ts
+++ b/e2e-mock-api/fixtures.ts
@@ -65,7 +65,12 @@ export const test = base.extend<{
         const nonce = url.searchParams.get("nonce") ?? "";
         const responseMode = url.searchParams.get("response_mode");
 
-        if (!redirectUri || !state) {
+        if (
+          redirectUri === null ||
+          redirectUri === "" ||
+          state === null ||
+          state === ""
+        ) {
           await route.abort();
           return;
         }
@@ -117,7 +122,7 @@ window.parent.postMessage({
       async (route) => {
         log("Auth0 token route hit");
         const body = route.request().postData();
-        if (!body) {
+        if (body === null || body === "") {
           await route.abort();
           return;
         }

--- a/e2e-mock-api/mockStore.ts
+++ b/e2e-mock-api/mockStore.ts
@@ -246,7 +246,7 @@ export class MockStore {
 
   updateAuthor(id: string, name: string, yomi = ""): Author | null {
     const author = this.authors.get(id);
-    if (!author) return null;
+    if (author == null) return null;
     const updated: Author = { id, name, yomi };
     this.authors.set(id, updated);
     this.recordAuthorEvent("UPDATE", id, name, yomi, null, null);
@@ -255,7 +255,7 @@ export class MockStore {
 
   deleteAuthor(id: string): boolean {
     const author = this.authors.get(id);
-    if (!author) return false;
+    if (author == null) return false;
     this.recordAuthorEvent("DELETE", id, author.name, author.yomi, null, null);
     const deleted = this.authors.delete(id);
     if (deleted) {
@@ -305,7 +305,7 @@ export class MockStore {
     >,
   ): Book | null {
     const book = this.books.get(bookData.id);
-    if (!book) return null;
+    if (book == null) return null;
 
     const now = Math.floor(Date.now() / 1000);
     const updatedBook: Book = {
@@ -320,7 +320,7 @@ export class MockStore {
 
   deleteBook(id: string): boolean {
     const book = this.books.get(id);
-    if (!book) return false;
+    if (book == null) return false;
     this.recordBookEvent("DELETE", book);
     return this.books.delete(id);
   }

--- a/e2e-mock-api/resolvers.ts
+++ b/e2e-mock-api/resolvers.ts
@@ -35,7 +35,7 @@ export const createResolvers = (mockStore: MockStore) => ({
         authorData.name,
         authorData.yomi ?? "",
       );
-      if (!updated) {
+      if (updated == null) {
         throw new Error(`Author not found: ${authorData.id}`);
       }
       return { author: updated };
@@ -56,7 +56,7 @@ export const createResolvers = (mockStore: MockStore) => ({
       { bookData }: { bookData: Parameters<typeof mockStore.updateBook>[0] },
     ) => {
       const updated = mockStore.updateBook(bookData);
-      if (!updated) {
+      if (updated == null) {
         throw new Error(`Book not found: ${bookData.id}`);
       }
       return { book: updated };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -110,7 +110,14 @@ export default tseslint.config(
       // compatibility warning for third-party libraries (e.g. TanStack Table).
       "react-hooks/incompatible-library": "off",
       "@typescript-eslint/no-unsafe-type-assertion": "error",
-      "@typescript-eslint/strict-boolean-expressions": "error",
+      "@typescript-eslint/strict-boolean-expressions": [
+        "error",
+        {
+          allowNullableObject: false,
+          allowNumber: false,
+          allowString: false,
+        },
+      ],
       "@typescript-eslint/consistent-type-definitions": ["warn", "type"],
       "no-plusplus": [
         "error",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -110,6 +110,7 @@ export default tseslint.config(
       // compatibility warning for third-party libraries (e.g. TanStack Table).
       "react-hooks/incompatible-library": "off",
       "@typescript-eslint/no-unsafe-type-assertion": "error",
+      "@typescript-eslint/strict-boolean-expressions": "error",
       "@typescript-eslint/consistent-type-definitions": ["warn", "type"],
       "no-plusplus": [
         "error",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,11 +4,13 @@ import {
   TEST_AUTH0_DOMAIN,
 } from "./e2e-mock-api/testConstants";
 
+const isCi = process.env.CI !== undefined && process.env.CI !== "";
+
 export default defineConfig({
   testDir: "./e2e-mock-api",
   fullyParallel: true,
-  forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  forbidOnly: isCi,
+  retries: isCi ? 2 : 0,
   use: {
     baseURL: "http://localhost:4173",
     trace: "on-first-retry",
@@ -23,7 +25,7 @@ export default defineConfig({
   webServer: {
     command: "npm run build && npm run preview",
     url: "http://localhost:4173",
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !isCi,
     stdout: "pipe",
     stderr: "pipe",
     env: {

--- a/playwright.demo.config.ts
+++ b/playwright.demo.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const isCi = process.env.CI !== undefined && process.env.CI !== "";
+
 export default defineConfig({
   testDir: "./e2e-demo-mode",
   fullyParallel: true,
-  forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  forbidOnly: isCi,
+  retries: isCi ? 2 : 0,
   use: {
     baseURL: "http://localhost:4173",
     trace: "off",
@@ -19,7 +21,7 @@ export default defineConfig({
   webServer: {
     command: "npm run build && npm run preview",
     url: "http://localhost:4173",
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !isCi,
     stdout: "pipe",
     stderr: "pipe",
     env: {

--- a/playwright.integration.config.ts
+++ b/playwright.integration.config.ts
@@ -4,11 +4,13 @@ import {
   TEST_AUTH0_DOMAIN,
 } from "./e2e-mock-api/testConstants";
 
+const isCi = process.env.CI !== undefined && process.env.CI !== "";
+
 export default defineConfig({
   testDir: "./e2e-integration",
   fullyParallel: false,
-  forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 1 : 0,
+  forbidOnly: isCi,
+  retries: isCi ? 1 : 0,
   workers: 1,
   use: {
     baseURL: "http://localhost:4173",

--- a/src/features/authors/AuthorHistory.test.tsx
+++ b/src/features/authors/AuthorHistory.test.tsx
@@ -257,7 +257,7 @@ describe("AuthorHistory", () => {
     });
 
     const rows = screen.getAllByRole("row");
-    const dataRows = rows.filter((row) => !row.querySelector("th"));
+    const dataRows = rows.filter((row) => row.querySelector("th") == null);
     expect(dataRows[0]).toHaveTextContent("UPDATE");
     expect(dataRows[1]).toHaveTextContent("CREATE");
   });

--- a/src/features/authors/AuthorHistory.tsx
+++ b/src/features/authors/AuthorHistory.tsx
@@ -22,11 +22,11 @@ export const AuthorHistory: React.FC<{ authorId: string }> = ({ authorId }) => {
     return <Text>Loading...</Text>;
   }
 
-  if (error) {
+  if (error != null) {
     return <Text>Error loading history</Text>;
   }
 
-  if (!data || data.authorEvents.length === 0) {
+  if (data == null || data.authorEvents.length === 0) {
     return null;
   }
 
@@ -81,7 +81,7 @@ export const AuthorHistory: React.FC<{ authorId: string }> = ({ authorId }) => {
         }}
         title="Event Detail"
       >
-        {selectedEvent && (
+        {selectedEvent != null && (
           <div>
             <Text>
               <strong>Operation:</strong> {selectedEvent.operation}

--- a/src/features/books/AuthorsCombobox.test.tsx
+++ b/src/features/books/AuthorsCombobox.test.tsx
@@ -188,7 +188,7 @@ describe("AuthorsCombobox", () => {
     const removeButton = container.querySelector(
       '[aria-label="Remove author name1"]',
     );
-    if (!removeButton) throw new Error("Remove button not found");
+    if (removeButton == null) throw new Error("Remove button not found");
     await user.click(removeButton);
 
     expect(onChange).toHaveBeenLastCalledWith([]);

--- a/src/features/books/AuthorsCombobox.tsx
+++ b/src/features/books/AuthorsCombobox.tsx
@@ -60,7 +60,7 @@ export const AuthorsCombobox: React.FC<AuthorsComboboxProps> = ({
         onChange(value.filter((a) => a.id !== val));
       } else {
         const author = authors.find((a) => a.id === val);
-        if (author) {
+        if (author != null) {
           onChange([...value, { id: author.id, name: author.name }]);
         }
       }
@@ -79,7 +79,7 @@ export const AuthorsCombobox: React.FC<AuthorsComboboxProps> = ({
   const commitPendingAuthorEdit = () => {
     if (editingAuthorId == null) return;
     const newName = editingName.trim();
-    if (newName) {
+    if (newName !== "") {
       onChange(
         value.map((a) =>
           a.id === editingAuthorId

--- a/src/features/books/AuthorsFilter.tsx
+++ b/src/features/books/AuthorsFilter.tsx
@@ -15,7 +15,7 @@ export const AuthorsFilter = <TData, TValue>({
     ? filterValue.filter((x): x is string => typeof x === "string")
     : [];
 
-  if (error) {
+  if (error != null) {
     console.error("AuthorsFilter: failed to load authors", error);
     return <div>An error occurred while loading authors</div>;
   }

--- a/src/features/books/BookCreateForm.tsx
+++ b/src/features/books/BookCreateForm.tsx
@@ -26,7 +26,7 @@ export const BookCreateForm: React.FC<BookCreateFormProps> = ({ form }) => {
   const { data, isLoading, error } = useAuthors();
   const [searchOpened, setSearchOpened] = useState(false);
 
-  if (error) {
+  if (error != null) {
     console.error(error);
     return <div>著者の読み込みに失敗しました。</div>;
   }

--- a/src/features/books/BookDetailModal.tsx
+++ b/src/features/books/BookDetailModal.tsx
@@ -27,7 +27,7 @@ export const BookDetailModal = ({
   const { state, fetch, reset } = useOpenBdDetail();
 
   useEffect(() => {
-    if (opened && searchResult.isbn) {
+    if (opened && searchResult.isbn !== "") {
       void fetch(searchResult.isbn);
     }
     if (!opened) {
@@ -38,6 +38,9 @@ export const BookDetailModal = ({
   const detail = state.status === "success" ? state.detail : null;
   const coverImageUrl =
     detail?.coverImageUrl ?? searchResult.coverImageUrl ?? null;
+  const seriesAndVolume = [detail?.series, detail?.volume]
+    .filter((value) => value !== undefined && value !== "")
+    .join(" ");
 
   const handleSelect = () => {
     onSelect(searchResult);
@@ -54,7 +57,7 @@ export const BookDetailModal = ({
       <Stack>
         {state.status === "loading" && <Loader />}
         <Group align="flex-start" wrap="nowrap">
-          {coverImageUrl && (
+          {coverImageUrl !== null && coverImageUrl !== "" && (
             <Image
               src={coverImageUrl}
               alt={searchResult.title}
@@ -64,16 +67,13 @@ export const BookDetailModal = ({
             />
           )}
           <Stack gap="xs" style={{ flex: 1 }}>
-            {(detail?.series ?? detail?.volume) && (
-              <Text size="sm">
-                {[detail.series, detail.volume].filter(Boolean).join(" ")}
-              </Text>
-            )}
-            {searchResult.subtitle && (
-              <Text size="sm" c="dimmed">
-                {searchResult.subtitle}
-              </Text>
-            )}
+            {seriesAndVolume !== "" && <Text size="sm">{seriesAndVolume}</Text>}
+            {searchResult.subtitle !== undefined &&
+              searchResult.subtitle !== "" && (
+                <Text size="sm" c="dimmed">
+                  {searchResult.subtitle}
+                </Text>
+              )}
             <Text>{searchResult.authorNames.join("、")}</Text>
             <Text size="sm" c="dimmed">
               {[
@@ -84,28 +84,35 @@ export const BookDetailModal = ({
                 .filter(Boolean)
                 .join("  ")}
             </Text>
-            {detail?.genre && <Text size="sm">ジャンル: {detail.genre}</Text>}
-            {detail?.format && <Text size="sm">判型: {detail.format}</Text>}
-            {detail?.pageCount && (
-              <Text size="sm">{detail.pageCount}ページ</Text>
+            {detail?.genre !== undefined && detail.genre !== "" && (
+              <Text size="sm">ジャンル: {detail.genre}</Text>
             )}
+            {detail?.format !== undefined && detail.format !== "" && (
+              <Text size="sm">判型: {detail.format}</Text>
+            )}
+            {detail?.pageCount !== undefined &&
+              detail.pageCount !== 0 &&
+              !Number.isNaN(detail.pageCount) && (
+                <Text size="sm">{detail.pageCount}ページ</Text>
+              )}
           </Stack>
         </Group>
-        {detail?.description && (
+        {detail?.description !== undefined && detail.description !== "" && (
           <Text size="sm" style={{ whiteSpace: "pre-wrap" }}>
             {detail.description}
           </Text>
         )}
-        {detail?.tableOfContents && (
-          <Stack gap={4}>
-            <Text size="sm" fw={700}>
-              目次
-            </Text>
-            <Text size="sm" style={{ whiteSpace: "pre-wrap" }}>
-              {detail.tableOfContents}
-            </Text>
-          </Stack>
-        )}
+        {detail?.tableOfContents !== undefined &&
+          detail.tableOfContents !== "" && (
+            <Stack gap={4}>
+              <Text size="sm" fw={700}>
+                目次
+              </Text>
+              <Text size="sm" style={{ whiteSpace: "pre-wrap" }}>
+                {detail.tableOfContents}
+              </Text>
+            </Stack>
+          )}
         {state.status === "error" && (
           <Text size="sm" c="dimmed">
             {state.message}

--- a/src/features/books/BookDetailShow.tsx
+++ b/src/features/books/BookDetailShow.tsx
@@ -33,7 +33,7 @@ const BookDetailShowItem: React.FC<{
       <Group
         align="center"
         style={{
-          gridColumn: halfWidth ? "span 1" : "2 / -1",
+          gridColumn: halfWidth === true ? "span 1" : "2 / -1",
         }}
       >
         {value}

--- a/src/features/books/BookHistory.test.tsx
+++ b/src/features/books/BookHistory.test.tsx
@@ -300,7 +300,7 @@ describe("BookHistory", () => {
     });
 
     const rows = screen.getAllByRole("row");
-    const dataRows = rows.filter((row) => !row.querySelector("th"));
+    const dataRows = rows.filter((row) => row.querySelector("th") == null);
     expect(dataRows[0]).toHaveTextContent("UPDATE");
     expect(dataRows[1]).toHaveTextContent("CREATE");
   });

--- a/src/features/books/BookHistory.tsx
+++ b/src/features/books/BookHistory.tsx
@@ -35,11 +35,11 @@ export const BookHistory: React.FC<BookHistoryProps> = ({
     return <Text>Loading...</Text>;
   }
 
-  if (error) {
+  if (error != null) {
     return <Text>Error loading history</Text>;
   }
 
-  if (!data || data.bookEvents.length === 0) {
+  if (data == null || data.bookEvents.length === 0) {
     return null;
   }
 
@@ -122,7 +122,7 @@ export const BookHistory: React.FC<BookHistoryProps> = ({
         }}
         title="Event Detail"
       >
-        {selectedEvent && (
+        {selectedEvent != null && (
           <div>
             <Text>
               <strong>Operation:</strong> {selectedEvent.operation}

--- a/src/features/books/BookList.test.tsx
+++ b/src/features/books/BookList.test.tsx
@@ -368,7 +368,9 @@ describe("BookList sorting", () => {
     const el = screen
       .getAllByText(name)
       .find((e) => e.closest("thead") !== null);
-    if (!el) throw new Error(`Header text "${name}" not found in thead`);
+    if (el == null) {
+      throw new Error(`Header text "${name}" not found in thead`);
+    }
     return el;
   };
 
@@ -385,7 +387,7 @@ describe("BookList sorting", () => {
     await waitFor(() => {
       const bodyRows = screen
         .getAllByRole("row")
-        .filter((r) => r.closest("tbody"));
+        .filter((r) => r.closest("tbody") != null);
       expect(within(bodyRows[0]).getByText("テスト書籍2")).toBeInTheDocument();
     });
   });
@@ -405,7 +407,7 @@ describe("BookList sorting", () => {
     await waitFor(() => {
       const bodyRows = screen
         .getAllByRole("row")
-        .filter((r) => r.closest("tbody"));
+        .filter((r) => r.closest("tbody") != null);
       expect(within(bodyRows[0]).getByText("テスト書籍4")).toBeInTheDocument();
     });
   });
@@ -423,7 +425,7 @@ describe("BookList sorting", () => {
     await waitFor(() => {
       const bodyRows = screen
         .getAllByRole("row")
-        .filter((r) => r.closest("tbody"));
+        .filter((r) => r.closest("tbody") != null);
       expect(within(bodyRows[0]).getByText("テスト書籍1")).toBeInTheDocument();
     });
   });

--- a/src/features/books/BookLookupDialog.tsx
+++ b/src/features/books/BookLookupDialog.tsx
@@ -45,7 +45,10 @@ export const BookLookupDialog = ({
   const trimmedPublisher = publisher.trim();
   const trimmedIsbn = isbn.trim();
   const isAllEmpty =
-    !trimmedTitle && !trimmedAuthorName && !trimmedPublisher && !trimmedIsbn;
+    trimmedTitle === "" &&
+    trimmedAuthorName === "" &&
+    trimmedPublisher === "" &&
+    trimmedIsbn === "";
 
   const handleSearch = () => {
     void search(
@@ -187,7 +190,7 @@ export const BookLookupDialog = ({
                           <Button
                             variant="outline"
                             size="xs"
-                            disabled={!result.isbn}
+                            disabled={result.isbn === ""}
                             onClick={(e) => {
                               e.stopPropagation();
                               setDetailResult(result);
@@ -216,7 +219,7 @@ export const BookLookupDialog = ({
           </Stack>
         )}
       </Stack>
-      {detailResult && (
+      {detailResult != null && (
         <BookDetailModal
           opened
           onClose={() => {

--- a/src/features/books/BookLookupDialog.tsx
+++ b/src/features/books/BookLookupDialog.tsx
@@ -113,58 +113,71 @@ export const BookLookupDialog = ({
             {state.results.map((result, index) => (
               <Box
                 key={
-                  result.isbn || `${backend}-${String(index)}-${result.title}`
+                  result.isbn !== ""
+                    ? result.isbn
+                    : `${backend}-${String(index)}-${result.title}`
                 }
                 component="div"
               >
                 <Paper p="xs" withBorder>
                   <Group align="flex-start" wrap="nowrap">
-                    {result.coverImageUrl && (
-                      <Image
-                        src={result.coverImageUrl}
-                        w={50}
-                        h={70}
-                        fit="contain"
-                        style={{ flexShrink: 0 }}
-                        alt={
-                          result.title
-                            ? `Cover of ${result.title}`
-                            : "Book cover"
-                        }
-                      />
-                    )}
+                    {result.coverImageUrl !== undefined &&
+                      result.coverImageUrl !== "" && (
+                        <Image
+                          src={result.coverImageUrl}
+                          w={50}
+                          h={70}
+                          fit="contain"
+                          style={{ flexShrink: 0 }}
+                          alt={
+                            result.title !== ""
+                              ? `Cover of ${result.title}`
+                              : "Book cover"
+                          }
+                        />
+                      )}
                     <Stack gap={2} style={{ flex: 1, minWidth: 0 }}>
                       <Text fw={700} lineClamp={2}>
                         {result.title}
                       </Text>
-                      {result.subtitle && (
-                        <Text size="sm" lineClamp={1}>
-                          {result.subtitle}
-                        </Text>
-                      )}
+                      {result.subtitle !== undefined &&
+                        result.subtitle !== "" && (
+                          <Text size="sm" lineClamp={1}>
+                            {result.subtitle}
+                          </Text>
+                        )}
                       <Text size="sm">{result.authorNames.join("、")}</Text>
-                      {(result.series ?? result.volume) && (
-                        <Text size="sm" c="dimmed">
-                          {[result.series, result.volume]
-                            .filter(Boolean)
-                            .join(" ")}
-                        </Text>
-                      )}
-                      {result.openBdFormat && (
-                        <Text size="sm" c="dimmed">
-                          {result.openBdFormat}
-                        </Text>
-                      )}
+                      {(result.series ?? result.volume) !== undefined &&
+                        (result.series ?? result.volume) !== "" && (
+                          <Text size="sm" c="dimmed">
+                            {[result.series, result.volume]
+                              .filter(
+                                (value) => value !== undefined && value !== "",
+                              )
+                              .join(" ")}
+                          </Text>
+                        )}
+                      {result.openBdFormat !== undefined &&
+                        result.openBdFormat !== "" && (
+                          <Text size="sm" c="dimmed">
+                            {result.openBdFormat}
+                          </Text>
+                        )}
                       <Group justify="space-between" align="flex-end">
                         <Stack gap={0}>
-                          {(result.publisher || result.publishedDate) && (
+                          {(result.publisher !== "" ||
+                            (result.publishedDate !== undefined &&
+                              result.publishedDate !== "")) && (
                             <Text size="sm" c="dimmed">
                               {[result.publisher, result.publishedDate]
-                                .filter(Boolean)
+                                .filter(
+                                  (value) =>
+                                    value !== undefined && value !== "",
+                                )
                                 .join(" ")}
                             </Text>
                           )}
-                          {result.isbn && (
+                          {result.isbn !== "" && (
                             <Text size="sm" c="dimmed">
                               ISBN: {result.isbn}
                             </Text>

--- a/src/features/books/BookUpdateForm.tsx
+++ b/src/features/books/BookUpdateForm.tsx
@@ -21,7 +21,7 @@ type BookUpdateFormProps = {
 export const BookUpdateForm: React.FC<BookUpdateFormProps> = ({ form }) => {
   const { data, isLoading, error } = useAuthors();
 
-  if (error) {
+  if (error != null) {
     return <div>{JSON.stringify(error)}</div>;
   }
 

--- a/src/features/books/useBookLookup.test.ts
+++ b/src/features/books/useBookLookup.test.ts
@@ -24,8 +24,8 @@ const ndlXml = (title: string, creators: string[], isbn = "", publisher = "") =>
       <title>${title}</title>
       <category>図書</category>
       ${creators.map((c) => `<dc:creator>${c}</dc:creator>`).join("")}
-      ${isbn ? `<dc:identifier xsi:type="dcndl:ISBN">${isbn}</dc:identifier>` : ""}
-      ${publisher ? `<dc:publisher>${publisher}</dc:publisher>` : ""}
+      ${isbn !== "" ? `<dc:identifier xsi:type="dcndl:ISBN">${isbn}</dc:identifier>` : ""}
+      ${publisher !== "" ? `<dc:publisher>${publisher}</dc:publisher>` : ""}
     </item>
   </channel>
 </rss>`;

--- a/src/features/books/useBookLookup.ts
+++ b/src/features/books/useBookLookup.ts
@@ -158,10 +158,18 @@ const searchGoogleBooks = async (
   query: BookLookupQuery,
 ): Promise<BookLookupResult[]> => {
   const parts: string[] = [];
-  if (query.title) parts.push(`intitle:${query.title}`);
-  if (query.authorName) parts.push(`inauthor:${query.authorName}`);
-  if (query.publisher) parts.push(`inpublisher:${query.publisher}`);
-  if (query.isbn) parts.push(`isbn:${query.isbn.replace(/-/g, "")}`);
+  if (query.title !== undefined && query.title !== "") {
+    parts.push(`intitle:${query.title}`);
+  }
+  if (query.authorName !== undefined && query.authorName !== "") {
+    parts.push(`inauthor:${query.authorName}`);
+  }
+  if (query.publisher !== undefined && query.publisher !== "") {
+    parts.push(`inpublisher:${query.publisher}`);
+  }
+  if (query.isbn !== undefined && query.isbn !== "") {
+    parts.push(`isbn:${query.isbn.replace(/-/g, "")}`);
+  }
 
   const encoded = encodeURIComponent(parts.join("+"));
   const response = await fetch(
@@ -172,7 +180,7 @@ const searchGoogleBooks = async (
   }
   const rawData: unknown = await response.json();
   const data = googleBooksResponseSchema.parse(rawData);
-  if (!data.items) return [];
+  if (data.items === undefined) return [];
 
   return data.items
     .map((item) => {
@@ -197,10 +205,18 @@ const searchNdl = async (
 ): Promise<BookLookupResult[]> => {
   const params = new URLSearchParams();
   params.set("mediaType", "1");
-  if (query.title) params.set("title", query.title);
-  if (query.authorName) params.set("creator", query.authorName);
-  if (query.publisher) params.set("publisher", query.publisher);
-  if (query.isbn) params.set("isbn", query.isbn.replace(/-/g, ""));
+  if (query.title !== undefined && query.title !== "") {
+    params.set("title", query.title);
+  }
+  if (query.authorName !== undefined && query.authorName !== "") {
+    params.set("creator", query.authorName);
+  }
+  if (query.publisher !== undefined && query.publisher !== "") {
+    params.set("publisher", query.publisher);
+  }
+  if (query.isbn !== undefined && query.isbn !== "") {
+    params.set("isbn", query.isbn.replace(/-/g, ""));
+  }
 
   const response = await fetch(`/ndl-proxy/api/opensearch?${params}`);
   if (!response.ok) {
@@ -266,7 +282,10 @@ export const useBookLookup = (): {
     backend: BookLookupBackend,
   ): Promise<void> => {
     const isEmpty =
-      !query.isbn && !query.title && !query.authorName && !query.publisher;
+      (query.isbn === undefined || query.isbn === "") &&
+      (query.title === undefined || query.title === "") &&
+      (query.authorName === undefined || query.authorName === "") &&
+      (query.publisher === undefined || query.publisher === "");
     if (isEmpty) {
       latestRequestIdRef.current += 1;
       setState({ status: "idle" });

--- a/src/features/books/useBookLookup.ts
+++ b/src/features/books/useBookLookup.ts
@@ -96,15 +96,17 @@ const enrichWithOpenBd = async (
     return results;
   }
 
-  const byRequestIsbn = new Map<string, OpenBdEnrichEntry>();
+  const byRequestIsbn = new Map<string, NonNullable<OpenBdEnrichEntry>>();
   for (let i = 0; i < uniqueIsbns.length; i++) {
     const entry = data[i];
-    if (entry) byRequestIsbn.set(uniqueIsbns[i], entry);
+    if (entry != null) {
+      byRequestIsbn.set(uniqueIsbns[i], entry);
+    }
   }
 
   return results.map((r) => {
     const entry = byRequestIsbn.get(r.isbn);
-    if (!entry) return r;
+    if (entry == null) return r;
     const isbn13 = entry.summary?.isbn;
     const cover = entry.summary?.cover;
     const rawTitle = entry.summary?.title;

--- a/src/features/books/useOpenBdDetail.ts
+++ b/src/features/books/useOpenBdDetail.ts
@@ -80,7 +80,7 @@ const findTextContent = (
 ): string | undefined => {
   for (const type of types) {
     const entry = textContents.find((t) => t.TextType === type);
-    if (entry?.Text) return entry.Text;
+    if (entry?.Text !== undefined && entry.Text !== "") return entry.Text;
   }
   return undefined;
 };

--- a/src/lib/graphqlClient.ts
+++ b/src/lib/graphqlClient.ts
@@ -4,7 +4,10 @@ import { graphqlApiUrl, isDemoMode } from "../config";
 
 export const createGraphQLClient = (accessToken?: string) => {
   const client = new GraphQLClient(graphqlApiUrl, {
-    headers: accessToken ? { authorization: `Bearer ${accessToken}` } : {},
+    headers:
+      accessToken !== undefined && accessToken !== ""
+        ? { authorization: `Bearer ${accessToken}` }
+        : {},
   });
   return getSdk(client);
 };

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -152,7 +152,7 @@ export const handlers = [
       );
     }
     const author = mockStore.getAuthor(variables.authorId);
-    if (!author) {
+    if (author == null) {
       return HttpResponse.json({
         data: { author: null },
       });
@@ -186,7 +186,7 @@ export const handlers = [
       );
     }
     const book = mockStore.getBook(variables.bookId);
-    if (!book) {
+    if (book == null) {
       return HttpResponse.json({
         data: { book: null },
       });
@@ -278,7 +278,7 @@ export const handlers = [
     }
     const yomi = isString(authorData.yomi) ? authorData.yomi : "";
     const author = mockStore.updateAuthor(authorData.id, authorData.name, yomi);
-    if (!author) {
+    if (author == null) {
       return HttpResponse.json(
         { errors: [{ message: `Author not found: ${authorData.id}` }] },
         { status: 200 },
@@ -399,7 +399,7 @@ export const handlers = [
     if (isString(bookData.format)) update.format = bookData.format;
     if (isString(bookData.store)) update.store = bookData.store;
     const book = mockStore.updateBook(update);
-    if (!book) {
+    if (book == null) {
       return HttpResponse.json(
         { errors: [{ message: `Book not found: ${bookId}` }] },
         { status: 200 },

--- a/src/mocks/mockStore.ts
+++ b/src/mocks/mockStore.ts
@@ -87,7 +87,7 @@ class MockStore {
 
   updateAuthor(id: string, name: string, yomi = ""): Author | null {
     const author = this.authors.get(id);
-    if (!author) return null;
+    if (author == null) return null;
     const updated: Author = { id, name, yomi };
     this.authors.set(id, updated);
     return updated;
@@ -125,7 +125,7 @@ class MockStore {
     >,
   ): Book | null {
     const book = this.books.get(bookData.id);
-    if (!book) return null;
+    if (book == null) return null;
 
     const now = Math.floor(Date.now() / 1000);
     const updatedBook: Book = {

--- a/src/routes/books/$id_.edit.tsx
+++ b/src/routes/books/$id_.edit.tsx
@@ -17,15 +17,15 @@ const BookDetailEditPage: React.FC = () => {
   const { id } = Route.useParams();
   const { data, isLoading, error } = useBook(id);
 
-  if (error) return <>{JSON.stringify(error)}</>;
-  if (isLoading || !data) {
+  if (error != null) return <>{JSON.stringify(error)}</>;
+  if (isLoading || data == null) {
     return (
       <Center>
         <Loader />
       </Center>
     );
   }
-  if (!data.book) return <div>Not found.</div>;
+  if (data.book == null) return <div>Not found.</div>;
 
   const book = graphQlBookToBook(data.book);
   return <BookDetailEdit book={book} />;


### PR DESCRIPTION
## Summary

- enable `@typescript-eslint/strict-boolean-expressions`
- disable `allowString`, `allowNumber`, and `allowNullableObject` so implicit truthy/falsy checks are rejected
- replace existing implicit checks with explicit boolean, nullish, empty-string, and numeric checks
- document `== null` / `!= null` as the preferred style when `null` and `undefined` do not need to be distinguished

## Why

The rule's defaults still allow non-nullable strings, numbers, and nullable objects in boolean contexts. Tightening these options ensures future code must state whether it is checking nullishness, emptiness, zero, or another specific condition.

For nullish checks, loose equality is intentional: `value == null` and `value != null` concisely cover both `null` and `undefined`. The existing `eqeqeq: ["error", "smart"]` configuration permits this usage.

## Validation

- `pnpm run generate`
- `pnpm run lint:fix`
- `TZ=UTC pnpm run test` (102 tests passed)
- `pnpm run typecheck`