### PR TITLE
Type-check local hook mocks

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -74,6 +74,20 @@ export default tseslint.config(
     ],
   },
   {
+    files: ["**/*.{test,spec}.{ts,tsx}"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "CallExpression[callee.object.name='vi'][callee.property.name='mock'] > Literal.arguments:first-child[value=/^\\.\\.?\\/(?:.*\\/)?use[A-Z][^/]*$/]",
+          message:
+            "Use vi.mock(import(...)) so local hook mocks are type-checked.",
+        },
+      ],
+    },
+  },
+  {
     rules: {
       eqeqeq: ["error", "smart"],
       "react/prop-types": "off",

--- a/src/features/authors/AuthorDetailEdit.test.tsx
+++ b/src/features/authors/AuthorDetailEdit.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { vi } from "vitest";
+import { useUpdateAuthor } from "../../compoments/hooks/useUpdateAuthor";
 import { AuthorDetailEdit } from "./AuthorDetailEdit";
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {
@@ -19,12 +20,11 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
 
 const mockMutateAsync = vi.fn().mockResolvedValue({});
 
-vi.mock("../../compoments/hooks/useUpdateAuthor", () => ({
-  useUpdateAuthor: () => ({
-    mutateAsync: mockMutateAsync,
-    isPending: false,
-  }),
-}));
+vi.mock(import("../../compoments/hooks/useUpdateAuthor"));
+vi.mocked(useUpdateAuthor, { partial: true }).mockReturnValue({
+  mutateAsync: mockMutateAsync,
+  isPending: false,
+});
 
 vi.mock("../../compoments/mantineTsr", () => ({
   Link: ({

--- a/src/features/authors/AuthorDetailShow.test.tsx
+++ b/src/features/authors/AuthorDetailShow.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { vi } from "vitest";
+import { useDeleteAuthor } from "../../compoments/hooks/useDeleteAuthor";
 import { AuthorDetailShow } from "./AuthorDetailShow";
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {
@@ -18,12 +19,11 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
 
 const mockMutateAsync = vi.fn().mockResolvedValue({});
 
-vi.mock("../../compoments/hooks/useDeleteAuthor", () => ({
-  useDeleteAuthor: () => ({
-    mutateAsync: mockMutateAsync,
-    isPending: false,
-  }),
-}));
+vi.mock(import("../../compoments/hooks/useDeleteAuthor"));
+vi.mocked(useDeleteAuthor, { partial: true }).mockReturnValue({
+  mutateAsync: mockMutateAsync,
+  isPending: false,
+});
 
 vi.mock("../../compoments/mantineTsr", () => ({
   Link: ({

--- a/src/features/authors/AuthorHistory.test.tsx
+++ b/src/features/authors/AuthorHistory.test.tsx
@@ -5,9 +5,13 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { vi } from "vitest";
+import { useAuthorEvents } from "../../compoments/hooks/useAuthorEvents";
+import type { AuthorEventsQuery } from "../../generated/graphql-request";
 import { AuthorHistory } from "./AuthorHistory";
 
-const mockUseAuthorEvents = vi.fn();
+vi.mock(import("../../compoments/hooks/useAuthorEvents"));
+
+const mockUseAuthorEvents = vi.mocked(useAuthorEvents, { partial: true });
 
 beforeAll(() => {
   Object.defineProperty(window, "matchMedia", {
@@ -37,11 +41,6 @@ beforeAll(() => {
   };
 });
 
-vi.mock("../../compoments/hooks/useAuthorEvents", () => ({
-  useAuthorEvents: (...args: unknown[]) =>
-    mockUseAuthorEvents(...args) as unknown,
-}));
-
 const createWrapper = (): React.FC<{ children: React.ReactNode }> => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -54,7 +53,7 @@ const createWrapper = (): React.FC<{ children: React.ReactNode }> => {
   return wrapper;
 };
 
-const mockEvents = {
+const mockEvents: AuthorEventsQuery = {
   authorEvents: [
     {
       eventId: "event-1",
@@ -133,7 +132,7 @@ describe("AuthorHistory", () => {
 
   test("renders loading state", () => {
     mockUseAuthorEvents.mockReturnValue({
-      data: null,
+      data: undefined,
       isLoading: true,
       error: null,
     });
@@ -147,7 +146,7 @@ describe("AuthorHistory", () => {
 
   test("renders error state", () => {
     mockUseAuthorEvents.mockReturnValue({
-      data: null,
+      data: undefined,
       isLoading: false,
       error: new Error("fail"),
     });
@@ -160,7 +159,7 @@ describe("AuthorHistory", () => {
   });
 
   test("renders UPDATE and DELETE operations", () => {
-    const eventsWithMultipleOperations = {
+    const eventsWithMultipleOperations: AuthorEventsQuery = {
       authorEvents: [
         {
           eventId: "event-1",
@@ -217,7 +216,7 @@ describe("AuthorHistory", () => {
   });
 
   test("displays events in descending order by changedAt", () => {
-    const eventsWithOrder = {
+    const eventsWithOrder: AuthorEventsQuery = {
       authorEvents: [
         {
           eventId: "event-2",

--- a/src/features/books/BookCreateForm.test.tsx
+++ b/src/features/books/BookCreateForm.test.tsx
@@ -7,28 +7,28 @@ import userEvent from "@testing-library/user-event";
 import { zod4Resolver } from "mantine-form-zod-resolver";
 import React from "react";
 import { vi } from "vitest";
+import { useAuthors } from "../../compoments/hooks/useAuthors";
 import { BookCreateForm } from "./BookCreateForm";
 import { bookFormSchema, BookFormValues } from "./bookFormSchema";
+import { useBookLookup } from "./useBookLookup";
 
-vi.mock("../../compoments/hooks/useAuthors", () => ({
-  useAuthors: () => ({
-    data: {
-      authors: [
-        { id: "1", name: "name1" },
-        { id: "2", name: "name2" },
-      ],
-    },
-    isLoading: false,
-    error: null,
-  }),
-}));
+vi.mock(import("../../compoments/hooks/useAuthors"));
+vi.mocked(useAuthors, { partial: true }).mockReturnValue({
+  data: {
+    authors: [
+      { id: "1", name: "name1", yomi: "" },
+      { id: "2", name: "name2", yomi: "" },
+    ],
+  },
+  isLoading: false,
+  error: null,
+});
 
-vi.mock("./useBookLookup", () => ({
-  useBookLookup: () => ({
-    state: { status: "idle" },
-    search: vi.fn(),
-  }),
-}));
+vi.mock(import("./useBookLookup"));
+vi.mocked(useBookLookup).mockReturnValue({
+  state: { status: "idle" },
+  search: vi.fn(),
+});
 
 beforeAll(() => {
   global.ResizeObserver = class ResizeObserver {

--- a/src/features/books/BookDetailShow.test.tsx
+++ b/src/features/books/BookDetailShow.test.tsx
@@ -3,6 +3,7 @@ import { MantineProvider } from "@mantine/core";
 import { render, screen, within } from "@testing-library/react";
 import React from "react";
 import { vi } from "vitest";
+import { useDeleteBook } from "../../compoments/hooks/useDeleteBook";
 import { BookDetailShow } from "./BookDetailShow";
 import type { Book } from "./entity/Book";
 
@@ -12,9 +13,10 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
   return { ...actual, useNavigate: () => vi.fn() };
 });
 
-vi.mock("../../compoments/hooks/useDeleteBook", () => ({
-  useDeleteBook: () => ({ mutateAsync: vi.fn() }),
-}));
+vi.mock(import("../../compoments/hooks/useDeleteBook"));
+vi.mocked(useDeleteBook, { partial: true }).mockReturnValue({
+  mutateAsync: vi.fn(),
+});
 
 vi.mock("../../compoments/mantineTsr", () => ({
   LinkButton: ({ children }: { children: React.ReactNode }) => (

--- a/src/features/books/BookHistory.test.tsx
+++ b/src/features/books/BookHistory.test.tsx
@@ -5,9 +5,13 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { vi } from "vitest";
+import { useBookEvents } from "../../compoments/hooks/useBookEvents";
+import type { BookEventsQuery } from "../../generated/graphql-request";
 import { BookHistory } from "./BookHistory";
 
-const mockUseBookEvents = vi.fn();
+vi.mock(import("../../compoments/hooks/useBookEvents"));
+
+const mockUseBookEvents = vi.mocked(useBookEvents, { partial: true });
 
 beforeAll(() => {
   Object.defineProperty(window, "matchMedia", {
@@ -37,10 +41,6 @@ beforeAll(() => {
   };
 });
 
-vi.mock("../../compoments/hooks/useBookEvents", () => ({
-  useBookEvents: (...args: unknown[]) => mockUseBookEvents(...args) as unknown,
-}));
-
 const createWrapper = (): React.FC<{ children: React.ReactNode }> => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -58,7 +58,7 @@ const mockAuthors = [
   { id: "author-2", name: "著者2", yomi: "ちょしゃに" },
 ];
 
-const mockEvents = {
+const mockEvents: BookEventsQuery = {
   bookEvents: [
     {
       eventId: "event-1",
@@ -146,7 +146,7 @@ describe("BookHistory", () => {
 
   test("renders loading state", () => {
     mockUseBookEvents.mockReturnValue({
-      data: null,
+      data: undefined,
       isLoading: true,
       error: null,
     });
@@ -160,7 +160,7 @@ describe("BookHistory", () => {
 
   test("renders error state", () => {
     mockUseBookEvents.mockReturnValue({
-      data: null,
+      data: undefined,
       isLoading: false,
       error: new Error("fail"),
     });
@@ -173,7 +173,7 @@ describe("BookHistory", () => {
   });
 
   test("renders UPDATE and DELETE operations", () => {
-    const eventsWithMultipleOperations = {
+    const eventsWithMultipleOperations: BookEventsQuery = {
       bookEvents: [
         {
           eventId: "event-1",
@@ -248,7 +248,7 @@ describe("BookHistory", () => {
   });
 
   test("displays events in descending order by changedAt", () => {
-    const eventsWithOrder = {
+    const eventsWithOrder: BookEventsQuery = {
       bookEvents: [
         {
           eventId: "event-2",

--- a/src/features/books/BookLookupDialog.test.tsx
+++ b/src/features/books/BookLookupDialog.test.tsx
@@ -4,16 +4,19 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 import { BookLookupDialog } from "./BookLookupDialog";
-import { BookLookupResult, BookLookupState } from "./useBookLookup";
+import {
+  BookLookupResult,
+  BookLookupState,
+  useBookLookup,
+} from "./useBookLookup";
 
 const mockSearch = vi.fn();
 let mockState: BookLookupState = { status: "idle" };
 
-vi.mock("./useBookLookup", () => ({
-  useBookLookup: () => ({
-    state: mockState,
-    search: mockSearch,
-  }),
+vi.mock(import("./useBookLookup"));
+vi.mocked(useBookLookup).mockImplementation(() => ({
+  state: mockState,
+  search: mockSearch,
 }));
 
 beforeAll(() => {

--- a/src/features/books/BookUpdateForm.test.tsx
+++ b/src/features/books/BookUpdateForm.test.tsx
@@ -7,21 +7,21 @@ import userEvent from "@testing-library/user-event";
 import { zod4Resolver } from "mantine-form-zod-resolver";
 import React from "react";
 import { vi } from "vitest";
+import { useAuthors } from "../../compoments/hooks/useAuthors";
 import { bookFormSchema, BookFormValues } from "./bookFormSchema";
 import { BookUpdateForm } from "./BookUpdateForm";
 
-vi.mock("../../compoments/hooks/useAuthors", () => ({
-  useAuthors: () => ({
-    data: {
-      authors: [
-        { id: "1", name: "name1" },
-        { id: "2", name: "name2" },
-      ],
-    },
-    isLoading: false,
-    error: null,
-  }),
-}));
+vi.mock(import("../../compoments/hooks/useAuthors"));
+vi.mocked(useAuthors, { partial: true }).mockReturnValue({
+  data: {
+    authors: [
+      { id: "1", name: "name1", yomi: "" },
+      { id: "2", name: "name2", yomi: "" },
+    ],
+  },
+  isLoading: false,
+  error: null,
+});
 
 // mock ResizeObserver
 beforeAll(() => {


### PR DESCRIPTION
## Summary

- migrate nine local hook mocks to Vitest's type-aware dynamic import API
- make intentional React Query partial returns explicit while fully checking
  `useBookLookup` returns
- reject string-path factory mocks for local `useXxx` modules in test files

## Why

The string-path `vi.mock(path, factory)` overload treats local hook factories
as unknown, allowing test mocks and GraphQL fixtures to drift from production
types without a type-checking failure.

This change preserves runtime behavior while making hook mocks and required
GraphQL response fields part of the TypeScript contract. The ESLint rule is
limited to relative `useXxx` modules, so router, Mantine, and other non-hook
mocks remain unaffected.

## Validation

- `pnpm run generate`
- `pnpm run lint:fix`
- `TZ=UTC pnpm run test` (17 files, 102 tests)
- `pnpm run typecheck`
- verified the new lint rule reports exactly 9 errors before migration and 0
  after migration

Closes #304


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **テスト**
  - テスト用モックの型チェックを強化し、誤ったモック設定を検出しやすくしました。
  - 著者・書籍関連機能のテストデータと状態表現を整理し、各種表示状態の検証精度を向上しました。

- **品質改善**
  - テストのモック設定方法を統一し、実際の機能仕様に近い検証を行えるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->