### PR TITLE
書籍詳細から著者詳細へリンクする

### DIFF
--- a/e2e-mock-api/books.spec.ts
+++ b/e2e-mock-api/books.spec.ts
@@ -58,6 +58,19 @@ test.describe("Books READ", () => {
     await expect(page.getByRole("button", { name: "削除" })).toBeVisible();
   });
 
+  test("navigates to author detail from book detail", async ({ page }) => {
+    await page.getByRole("link", { name: "テスト書籍1" }).click();
+    await expect(page).toHaveURL(/\/books\/book-1$/);
+
+    await page
+      .getByTestId("book-detail")
+      .getByRole("link", { name: "著者1" })
+      .click();
+
+    await expect(page).toHaveURL(/\/authors\/author-1$/);
+    await expect(page.getByRole("heading", { name: "著者1" })).toBeVisible();
+  });
+
   test("returns to list with Back button", async ({ page }) => {
     await page.getByRole("link", { name: "テスト書籍1" }).click();
     await expect(page).toHaveURL(/\/books\/book-1$/);

--- a/openspec/changes/link-book-authors/.openspec.yaml
+++ b/openspec/changes/link-book-authors/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/link-book-authors/design.md
+++ b/openspec/changes/link-book-authors/design.md
@@ -1,0 +1,27 @@
+## Context
+
+`BookDetailShow` currently joins author names into one text value. The application already exposes a typed Mantine/TanStack Router `Link` and an `/authors/$id` detail route, while each book author already includes the required `id`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make each author name independently navigable from a book detail page.
+- Retain the existing visual ordering and comma-separated presentation.
+- Cover link destinations at component level and the user flow at E2E level.
+
+**Non-Goals:**
+
+- Changing author or book data models, GraphQL operations, or routes.
+- Linking author readings or author names shown outside the book detail page.
+
+## Decisions
+
+- Use the existing `Link` wrapper from `compoments/mantineTsr`, targeting `/authors/$id` with each author's ID. This preserves typed routing, Mantine styling, and intent preloading consistently with the author list.
+- Render separators as text between links rather than joining names into one string. This keeps the current comma-and-space appearance while giving every author its own accessible link.
+- Extend `BookDetailShow`'s component test to assert link names and destinations, and add a mock-API E2E navigation test because the change is a critical cross-screen interaction.
+
+## Risks / Trade-offs
+
+- [The component test currently mocks only `LinkButton`] → Extend the module mock with a lightweight anchor implementation of `Link` that exposes the generated author URL.
+- [Multiple links and separators could change wrapping] → Keep all nodes in the existing `Group`, allowing its current layout behavior to handle wrapping.

--- a/openspec/changes/link-book-authors/proposal.md
+++ b/openspec/changes/link-book-authors/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Book detail pages show author names as plain text, forcing users to return to the author list to open an author's details. Linking each displayed author directly improves navigation between related records.
+
+## What Changes
+
+- Render every author name on a book detail page as a link to that author's detail page.
+- Preserve the existing comma-separated author presentation and author-reading display.
+- Add component and end-to-end coverage for the author-detail navigation.
+
+## Capabilities
+
+### New Capabilities
+
+- `book-author-navigation`: Navigation from authors displayed on a book detail page to their author detail pages.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Book detail presentation in `src/features/books/BookDetailShow.tsx`.
+- Book detail component tests and mock-API end-to-end tests.
+- No API, GraphQL schema, or dependency changes.

--- a/openspec/changes/link-book-authors/specs/book-author-navigation/spec.md
+++ b/openspec/changes/link-book-authors/specs/book-author-navigation/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Book authors link to author details
+The system SHALL display every author name on a book detail page as an individual link to that author's detail page.
+
+#### Scenario: Navigate to an author from a book detail
+- **WHEN** a user selects an author name displayed on a book detail page
+- **THEN** the system navigates to the detail page identified by that author's ID
+
+#### Scenario: Display multiple linked authors
+- **WHEN** a book has multiple authors
+- **THEN** the system displays the authors in their existing order with comma-and-space separators and makes each author name independently navigable
+
+### Requirement: Author readings remain informational
+The system SHALL continue to display author readings separately from author-name links.
+
+#### Scenario: Display author readings with linked names
+- **WHEN** a book detail page displays linked author names
+- **THEN** the author readings remain visible in their existing comma-separated format

--- a/openspec/changes/link-book-authors/tasks.md
+++ b/openspec/changes/link-book-authors/tasks.md
@@ -1,0 +1,9 @@
+## 1. Book Detail Navigation
+
+- [x] 1.1 Render each book author as a typed link to `/authors/$id` while preserving separators and author readings
+- [x] 1.2 Update `BookDetailShow` component tests to verify author link labels and destinations
+
+## 2. User Flow Verification
+
+- [x] 2.1 Add a mock-API E2E test that navigates from a book detail author link to the matching author detail page
+- [x] 2.2 Run generation, formatting, unit tests, type checking, and the relevant mock-API E2E suite

--- a/src/features/books/BookDetailShow.test.tsx
+++ b/src/features/books/BookDetailShow.test.tsx
@@ -19,6 +19,13 @@ vi.mocked(useDeleteBook, { partial: true }).mockReturnValue({
 });
 
 vi.mock("../../compoments/mantineTsr", () => ({
+  Link: ({
+    children,
+    params,
+  }: {
+    children: React.ReactNode;
+    params: { id: string };
+  }) => <a href={`/authors/${params.id}`}>{children}</a>,
   LinkButton: ({ children }: { children: React.ReactNode }) => (
     <button type="button">{children}</button>
   ),
@@ -66,7 +73,13 @@ test("shows authors and author readings as separate items", () => {
 
   const detail = screen.getByTestId("book-detail");
   expect(within(detail).getByText("著者")).toBeInTheDocument();
-  expect(within(detail).getByText("山田太郎, 鈴木花子")).toBeInTheDocument();
+  expect(
+    within(detail).getByRole("link", { name: "山田太郎" }),
+  ).toHaveAttribute("href", "/authors/author-1");
+  expect(
+    within(detail).getByRole("link", { name: "鈴木花子" }),
+  ).toHaveAttribute("href", "/authors/author-2");
+  expect(detail).toHaveTextContent("山田太郎, 鈴木花子");
   expect(within(detail).getByText("著者読み仮名")).toBeInTheDocument();
   expect(
     within(detail).getByText("やまだたろう, すずきはなこ"),

--- a/src/features/books/BookDetailShow.test.tsx
+++ b/src/features/books/BookDetailShow.test.tsx
@@ -27,9 +27,7 @@ vi.mock("../../compoments/mantineTsr", () => ({
     children: React.ReactNode;
     to: string;
     params: { id: string };
-  }) => (
-    <a href={to.replace("$id", params.id)}>{children}</a>
-  ),
+  }) => <a href={to.replace("$id", params.id)}>{children}</a>,
   LinkButton: ({ children }: { children: React.ReactNode }) => (
     <button type="button">{children}</button>
   ),

--- a/src/features/books/BookDetailShow.test.tsx
+++ b/src/features/books/BookDetailShow.test.tsx
@@ -73,12 +73,16 @@ test("shows authors and author readings as separate items", () => {
 
   const detail = screen.getByTestId("book-detail");
   expect(within(detail).getByText("著者")).toBeInTheDocument();
-  expect(
-    within(detail).getByRole("link", { name: "山田太郎" }),
-  ).toHaveAttribute("href", "/authors/author-1");
-  expect(
-    within(detail).getByRole("link", { name: "鈴木花子" }),
-  ).toHaveAttribute("href", "/authors/author-2");
+  const firstAuthorLink = within(detail).getByRole("link", {
+    name: "山田太郎",
+  });
+  const secondAuthorLink = within(detail).getByRole("link", {
+    name: "鈴木花子",
+  });
+  expect(firstAuthorLink).toHaveAttribute("href", "/authors/author-1");
+  expect(secondAuthorLink).toHaveAttribute("href", "/authors/author-2");
+  expect(firstAuthorLink.parentElement).toBe(secondAuthorLink.parentElement);
+  expect(firstAuthorLink.parentElement).toHaveTextContent("山田太郎, 鈴木花子");
   expect(detail).toHaveTextContent("山田太郎, 鈴木花子");
   expect(within(detail).getByText("著者読み仮名")).toBeInTheDocument();
   expect(

--- a/src/features/books/BookDetailShow.test.tsx
+++ b/src/features/books/BookDetailShow.test.tsx
@@ -21,11 +21,15 @@ vi.mocked(useDeleteBook, { partial: true }).mockReturnValue({
 vi.mock("../../compoments/mantineTsr", () => ({
   Link: ({
     children,
+    to,
     params,
   }: {
     children: React.ReactNode;
+    to: string;
     params: { id: string };
-  }) => <a href={`/authors/${params.id}`}>{children}</a>,
+  }) => (
+    <a href={to.replace("$id", params.id)}>{children}</a>
+  ),
   LinkButton: ({ children }: { children: React.ReactNode }) => (
     <button type="button">{children}</button>
   ),

--- a/src/features/books/BookDetailShow.tsx
+++ b/src/features/books/BookDetailShow.tsx
@@ -14,7 +14,7 @@ import { IconArrowBack } from "@tabler/icons-react";
 import { useNavigate } from "@tanstack/react-router";
 import dayjs from "dayjs";
 import React, { useState } from "react";
-import { LinkButton } from "../../compoments/mantineTsr";
+import { Link, LinkButton } from "../../compoments/mantineTsr";
 import { ShowBoolean } from "../../compoments/utils/ShowBoolean";
 import { useDeleteBook } from "../../compoments/hooks/useDeleteBook";
 import { Book } from "./entity/Book";
@@ -129,7 +129,14 @@ export const BookDetailShow: React.FC<{ book: Book }> = (props) => {
         <BookDetailShowItem field="書名" value={book.title} />
         <BookDetailShowItem
           field="著者"
-          value={book.authors.map((author) => author.name).join(", ")}
+          value={book.authors.map((author, index) => (
+            <React.Fragment key={author.id}>
+              {index > 0 && ", "}
+              <Link to="/authors/$id" params={{ id: author.id }}>
+                {author.name}
+              </Link>
+            </React.Fragment>
+          ))}
         />
         <BookDetailShowItem
           field="著者読み仮名"

--- a/src/features/books/BookDetailShow.tsx
+++ b/src/features/books/BookDetailShow.tsx
@@ -129,14 +129,18 @@ export const BookDetailShow: React.FC<{ book: Book }> = (props) => {
         <BookDetailShowItem field="書名" value={book.title} />
         <BookDetailShowItem
           field="著者"
-          value={book.authors.map((author, index) => (
-            <React.Fragment key={author.id}>
-              {index > 0 && ", "}
-              <Link to="/authors/$id" params={{ id: author.id }}>
-                {author.name}
-              </Link>
-            </React.Fragment>
-          ))}
+          value={
+            <Text component="span">
+              {book.authors.map((author, index) => (
+                <React.Fragment key={author.id}>
+                  {index > 0 && ", "}
+                  <Link to="/authors/$id" params={{ id: author.id }}>
+                    {author.name}
+                  </Link>
+                </React.Fragment>
+              ))}
+            </Text>
+          }
         />
         <BookDetailShowItem
           field="著者読み仮名"


### PR DESCRIPTION
## 概要

- 書籍詳細に表示される各著者名を著者詳細へのリンクに変更
- 複数著者の表示順・カンマ区切り・著者読み仮名の表示を維持
- コンポーネントテストとmock API E2Eテストを追加
- OpenSpecのproposal、design、spec、tasksを追加

## 背景

書籍詳細の著者名がプレーンテキストだったため、関連する著者詳細を開くには著者一覧へ戻る必要がありました。この変更により、書籍詳細から対応する著者へ直接移動できます。

## 設計

既存のMantine/TanStack Router統合済みtyped `Link` を使用し、各著者IDを `/authors/$id` へ渡します。API、GraphQLスキーマ、データモデル、ルート定義の変更はありません。

## 検証

- `pnpm run generate`
- `pnpm run lint:fix`
- `pnpm run test`（17 files / 102 tests passed）
- `pnpm run typecheck`
- `pnpm run test:e2e:mock-api`（44 tests passed）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 書籍詳細ページの各著者名から、対応する著者詳細ページへ移動できるようになりました。
  * 複数の著者名は、従来どおりカンマ区切りで表示されます。

* **テスト**
  * 著者リンクの表示と著者詳細ページへの遷移を確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->